### PR TITLE
Fix coordinate problem for retina displays

### DIFF
--- a/labelCloud/utils/oglhelper.py
+++ b/labelCloud/utils/oglhelper.py
@@ -12,7 +12,7 @@ from model.point_cloud import PointCloud
 Color4f = Tuple[float, float, float, float]  # type alias for type hinting
 PointList = List[List[float]]
 
-device_pixel_ratio = None
+DEVICE_PIXEL_RATIO = None  # is set once and for every window resize (retina display fix)
 
 
 def draw_points(points: PointList, color: Color4f = (0, 1, 1, 1), point_size: int = 10) -> None:
@@ -98,8 +98,8 @@ def get_pick_ray(x: float, y: float, modelview, projection) -> Tuple[List[float]
     :param projection: projection matrix
     :return: two points of the pick ray from the closest and furthest frustum
     """
-    x *= device_pixel_ratio
-    y *= device_pixel_ratio
+    x *= DEVICE_PIXEL_RATIO
+    y *= DEVICE_PIXEL_RATIO
 
     viewport = GL.glGetIntegerv(GL.GL_VIEWPORT)
     real_y = viewport[3] - y  # adjust for down-facing y positions

--- a/labelCloud/utils/oglhelper.py
+++ b/labelCloud/utils/oglhelper.py
@@ -12,6 +12,8 @@ from model.point_cloud import PointCloud
 Color4f = Tuple[float, float, float, float]  # type alias for type hinting
 PointList = List[List[float]]
 
+device_pixel_ratio = None
+
 
 def draw_points(points: PointList, color: Color4f = (0, 1, 1, 1), point_size: int = 10) -> None:
     GL.glColor4d(*color)
@@ -96,6 +98,9 @@ def get_pick_ray(x: float, y: float, modelview, projection) -> Tuple[List[float]
     :param projection: projection matrix
     :return: two points of the pick ray from the closest and furthest frustum
     """
+    x *= device_pixel_ratio
+    y *= device_pixel_ratio
+
     viewport = GL.glGetIntegerv(GL.GL_VIEWPORT)
     real_y = viewport[3] - y  # adjust for down-facing y positions
 

--- a/labelCloud/view/viewer.py
+++ b/labelCloud/view/viewer.py
@@ -15,6 +15,7 @@ from control.drawing_manager import DrawingManager
 
 # Main widget for presenting the point cloud
 class GLWidget(QtOpenGL.QGLWidget):
+
     def __init__(self, parent=None):
         self.parent = parent
         QtOpenGL.QGLWidget.__init__(self, parent)
@@ -22,6 +23,8 @@ class GLWidget(QtOpenGL.QGLWidget):
 
         self.modelview = None
         self.projection = None
+        self.DEVICE_PIXEL_RATIO = self.devicePixelRatioF()  # 1 = normal; 2 = retina display
+        oglhelper.DEVICE_PIXEL_RATIO = self.DEVICE_PIXEL_RATIO  # set for helper functions
 
         self.pcd_controller = None
         self.bbox_controller = None
@@ -62,8 +65,6 @@ class GLWidget(QtOpenGL.QGLWidget):
 
         GLU.gluPerspective(45.0, aspect, 0.5, 30.0)
         GL.glMatrixMode(GL.GL_MODELVIEW)
-
-        oglhelper.device_pixel_ratio = self.devicePixelRatioF()
 
     def paintGL(self):
         GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)
@@ -113,10 +114,8 @@ class GLWidget(QtOpenGL.QGLWidget):
 
     # Translates the 2D cursor position from screen plane into 3D world space coordinates
     def get_world_coords(self, x: int, y: int, z: float = None, correction: bool = False):
-        device_pixel_ratio = self.devicePixelRatioF()  # For fixing mac retina bug
-        print(f"DEBUG: Device pixel ratio is: {device_pixel_ratio}")
-        x *= device_pixel_ratio
-        y *= device_pixel_ratio
+        x *= self.DEVICE_PIXEL_RATIO  # For fixing mac retina bug
+        y *= self.DEVICE_PIXEL_RATIO
 
         viewport = GL.glGetIntegerv(GL.GL_VIEWPORT)  # Stored projection matrices are taken from loop
         real_y = viewport[3] - y  # adjust for down-facing y positions

--- a/labelCloud/view/viewer.py
+++ b/labelCloud/view/viewer.py
@@ -63,6 +63,8 @@ class GLWidget(QtOpenGL.QGLWidget):
         GLU.gluPerspective(45.0, aspect, 0.5, 30.0)
         GL.glMatrixMode(GL.GL_MODELVIEW)
 
+        oglhelper.device_pixel_ratio = self.devicePixelRatioF()
+
     def paintGL(self):
         GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)
         GL.glPushMatrix()  # push the current matrix to the current stack
@@ -111,6 +113,11 @@ class GLWidget(QtOpenGL.QGLWidget):
 
     # Translates the 2D cursor position from screen plane into 3D world space coordinates
     def get_world_coords(self, x: int, y: int, z: float = None, correction: bool = False):
+        device_pixel_ratio = self.devicePixelRatioF()  # For fixing mac retina bug
+        print(f"DEBUG: Device pixel ratio is: {device_pixel_ratio}")
+        x *= device_pixel_ratio
+        y *= device_pixel_ratio
+
         viewport = GL.glGetIntegerv(GL.GL_VIEWPORT)  # Stored projection matrices are taken from loop
         real_y = viewport[3] - y  # adjust for down-facing y positions
 


### PR DESCRIPTION
Problem: Cursor was off by fixed distance for retina displays due to wrong coordinate calculation of `GLU.unproject()`

Solution: Consider `display pixel ratio` when calculating coordinates from screen coordinates.

Closes #7 