### PR TITLE
Fix mac style

### DIFF
--- a/labelCloud/app.py
+++ b/labelCloud/app.py
@@ -24,4 +24,7 @@ def get_main_app():
 
 def run():
     app, _ = get_main_app()
+
+    app.setStyle("Fusion")
+
     sys.exit(app.exec_())

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -46,6 +46,8 @@ class GUI(QtWidgets.QMainWindow):
         self.setWindowTitle("labelCloud")
 
         # MENU BAR
+        self.menu_bar = self.findChild(QtWidgets.QMenuBar, "menubar")
+        self.menu_bar.setNativeMenuBar(False)
         # File
         self.action_setpcdfolder = self.findChild(
             QtWidgets.QAction, "action_setpcdfolder"


### PR DESCRIPTION
The labelCloud UI looks very different on MacOS compared to Linux.

- Fix this issue by enforcing a generic design.
- Fix the disappearance of ticks in the menu bar by forbidding native menu bars