### PR TITLE
simpler initial viewpoint computation

### DIFF
--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -176,13 +176,10 @@ class PointCloudManger:
             tmp_pcd.colorless = False
 
         max_dims = np.subtract(tmp_pcd.pcd_maxs, tmp_pcd.pcd_mins)
-        init_trans_z = max(
-            tmp_pcd.center[2] - max(((max(max_dims[:2]) / 2) / np.tan(0.39) + 2), -15),
-            -25,
-        )
-        init_trans_x = -tmp_pcd.center[0] + max_dims[0] * 0.1
-        init_trans_y = -tmp_pcd.center[1] + max_dims[1] * -0.1
-        tmp_pcd.init_translation = init_trans_x, init_trans_y, init_trans_z
+        diagonal = np.linalg.norm(max_dims)
+
+        tmp_pcd.init_translation = -self.current_o3d_pcd.get_center() - [0, 0, diagonal]
+
         tmp_pcd.reset_translation()
         tmp_pcd.print_details()
         if self.pointcloud is not None:  # Skip first pcd to intialize OpenGL first


### PR DESCRIPTION
Hi Christoph,

Thanks for putting this tool together - great work!

For my project, I'm working with large pointclouds, e.g.:

> Point Cloud Center:		[  5.33   9.52 498.09]
> Point Cloud Minimums:	[-218.82 -310.2   484.31]
> Point Cloud Maximums:	[278.17 312.32 534.99]

The previous trans_init computation didn't quite work for this use case - here is a simpler and more robust one I believe.

