### PR TITLE
Add necessary transformation to KITTI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The tool is designed to be easily adaptable to multiple use cases. To change the
 | `centroid_abs` | Centroid `[x, y, z]`; Dimensions `[length, width, height]`; <br> Absolute Rotations as Euler angles in degrees (0..360°) `[yaw, pitch, roll]` |
 | `vertices` | 8 Vertices of the bounding box each with `[x, y, z]` (see [documentation.md](docs/documentation.md) for order) |
 | `kitti` | Centroid; Dimensions; z-Rotation (See [specification](https://github.com/bostondiditeam/kitti/blob/master/resources/devkit_object/readme.txt)) |
+| `kitti_untransformed` | See above, but without transformations. |
 
 You can easily create your own exporter by subclassing the abstract [BaseLabelFormat](https://github.com/ch-sa/labelCloud/blob/master/labelCloud/label_formats/base.py#L10).
 All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the positive x- to the negative y-axis!).

--- a/labelCloud/control/label_manager.py
+++ b/labelCloud/control/label_manager.py
@@ -19,6 +19,13 @@ def get_label_strategy(export_format: str, label_folder: str) -> "BaseLabelForma
         return KittiFormat(
             label_folder, LabelManager.EXPORT_PRECISION, relative_rotation=True
         )
+    elif export_format == "kitti_untransformed":
+        return KittiFormat(
+            label_folder,
+            LabelManager.EXPORT_PRECISION,
+            relative_rotation=True,
+            transformed=False,
+        )
     elif export_format != "centroid_abs":
         print(
             f"Unknown export strategy '{export_format}'. Proceeding with default (centroid_abs)!"

--- a/tests/unit/test_label_export.py
+++ b/tests/unit/test_label_export.py
@@ -89,7 +89,9 @@ def test_centroid_abs_export(bounding_box, tmpdir):
 
 
 def test_kitti_export(bounding_box, tmpdir):
-    label_manager = LabelManager(strategy="kitti", path_to_label_folder=tmpdir)
+    label_manager = LabelManager(
+        strategy="kitti_untransformed", path_to_label_folder=tmpdir
+    )
     label_manager.export_labels("testfolder/testpcd.ply", [bounding_box])
 
     with open(os.path.join(tmpdir, "testpcd.txt"), "r") as read_file:

--- a/tests/unit/test_label_import.py
+++ b/tests/unit/test_label_import.py
@@ -74,7 +74,9 @@ def test_kitti(label_kitti, tmpdir):
         write_file.write(label_kitti)
 
     # Import label file
-    label_manager = LabelManager(strategy="kitti", path_to_label_folder=tmpdir)
+    label_manager = LabelManager(
+        strategy="kitti_untransformed", path_to_label_folder=tmpdir
+    )
     bounding_boxes = label_manager.import_labels("test.txt")
     bbox = bounding_boxes[0]
 


### PR DESCRIPTION
 - transform the position, dimension and rotation of KITTI labels before
  loading or saving
  - add kitti_untransformed for backward compatibility

Thanks to @sondisonda for finding the correct transformation.

Closes: #35