### PR TITLE
Address Open3D *.pcd bug

### DIFF
--- a/labelCloud/io/pointclouds/open3d.py
+++ b/labelCloud/io/pointclouds/open3d.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple
 
@@ -5,6 +6,7 @@ import numpy as np
 import open3d as o3d
 
 from . import BasePointCloudHandler
+from ...utils.logger import bold, end_section, red, start_section
 
 if TYPE_CHECKING:
     from ...model import PointCloud
@@ -34,6 +36,15 @@ class Open3DHandler(BasePointCloudHandler):
         return o3d_pointcloud
 
     def read_point_cloud(self, path: Path) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        if path.suffix == ".pcd":
+            start_section(bold("IO WARNING"))
+            logging.warning(
+                "Loading *.pcd point clouds with Open3D currently leads to issues on Linux systems."
+                "\n --> See https://github.com/isl-org/Open3D/issues/4969 for more details."
+                "\n --> See https://github.com/ch-sa/labelCloud/issues/68#issuecomment-1086892957 for a workaround."
+            )
+            end_section()
+
         super().read_point_cloud(path)
         return self.to_point_cloud(
             o3d.io.read_point_cloud(str(path), remove_nan_points=True)

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -3,9 +3,10 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+import pkg_resources
+
 import numpy as np
 import OpenGL.GL as GL
-import pkg_resources
 
 from . import Perspective
 from ..control.config_manager import config
@@ -44,7 +45,15 @@ def calculate_init_translation(
     return -np.add(center, [0, 0, zoom])
 
 
-def colorize_points(points: np.ndarray, z_min: float, z_max: float) -> np.ndarray:
+def colorize_points(
+    points: np.ndarray, z_min: float, z_max: float
+) -> Optional[np.ndarray]:
+    if z_min == z_max:
+        logging.warning(
+            "All points in the point cloud have the same height. Skipping colorization ..."
+        )
+        return None
+
     palette = np.loadtxt(
         pkg_resources.resource_filename("labelCloud.resources", "rocket-palette.txt")
     )


### PR DESCRIPTION
Loading point clouds in `*.pcd` format on Linux systems within a PyQt application is leading to rounded point coordinates:
https://github.com/isl-org/Open3D/issues/4969

This PR:
 - catches the attempt to colorize a point cloud with no difference in z-values (height)
 - warns users when loading `*.pcd` point clouds