### PR TITLE
Blend point colors with labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ cython_debug/
 
 # Mac Stuff
 *.DS_Store
+
+# pyenv local
+.python-version

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,5 @@
 [MODE]
 segmentation = true
-label_folder = labels/
 
 [FILE]
 ; source of point clouds
@@ -21,6 +20,10 @@ colorless_colorize = True
 std_translation = 0.03
 ; standard step for zooming (for scrolling)
 std_zoom = 0.0025
+; blend the color with segmentation labels
+color_with_label = True
+; mix ratio between label colors and rgb colors
+label_color_mix_ratio = 0.3
 
 [LABEL]
 ; format for exporting labels. choose from (vertices, centroid_rel, centroid_abs, kitti)

--- a/config.ini
+++ b/config.ini
@@ -21,7 +21,7 @@ std_translation = 0.03
 ; standard step for zooming (for scrolling)
 std_zoom = 0.0025
 ; blend the color with segmentation labels
-color_with_label = True
+color_with_label = False
 ; mix ratio between label colors and rgb colors
 label_color_mix_ratio = 0.3
 

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,7 @@
+[MODE]
+segmentation = true
+label_folder = labels/
+
 [FILE]
 ; source of point clouds
 pointcloud_folder = pointclouds/

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -26,6 +26,7 @@ class PointCloudManger(object):
     ORIGINALS_FOLDER = "original_pointclouds"
     TRANSLATION_FACTOR = config.getfloat("POINTCLOUD", "STD_TRANSLATION")
     ZOOM_FACTOR = config.getfloat("POINTCLOUD", "STD_ZOOM")
+    SEGMENTATION = config.getboolean("MODE", "SEGMENTATION")
 
     def __init__(self) -> None:
         # Point cloud management

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -73,8 +73,6 @@ class PointCloud(object):
         self.trans_x, self.trans_y, self.trans_z = self.init_translation
         self.rot_x, self.rot_y, self.rot_z = self.init_rotation
 
-        self.point_size = config.getfloat("POINTCLOUD", "point_size")
-
         if self.colorless:
             # if no color in point cloud, either color with height or color with a single color
             if config.getboolean("POINTCLOUD", "COLORLESS_COLORIZE"):
@@ -101,6 +99,10 @@ class PointCloud(object):
         logging.info(green(f"Successfully loaded point cloud from {path}!"))
         self.print_details()
         end_section()
+
+    @property
+    def point_size(self) -> float:
+        return config.getfloat("POINTCLOUD", "point_size")
 
     def create_buffers(self) -> None:
         """Create 3 different buffers holding points, colors and label colors information"""
@@ -181,8 +183,12 @@ class PointCloud(object):
         )
 
     @property
-    def colorless(self):
+    def colorless(self) -> bool:
         return self.colors is None
+
+    @property
+    def color_with_label(self) -> bool:
+        return config.getboolean("POINTCLOUD", "color_with_label")
 
     # GETTERS AND SETTERS
     def get_no_of_points(self) -> int:
@@ -269,7 +275,7 @@ class PointCloud(object):
         GL.glVertexPointer(3, GL.GL_FLOAT, stride, None)
 
         # Bind color buffer
-        if config.getboolean("POINTCLOUD", "color_with_label"):
+        if self.color_with_label:
             color_vbo = self.label_vbo
         else:
             color_vbo = self.color_vbo

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -238,7 +238,7 @@ class PointCloud(object):
             attributes = self.points
         else:
             # Merge coordinates and colors in alternating order
-            attributes = np.concatenate((self.points, self.label_colors), axis=1)
+            attributes = np.concatenate((self.points, self.colors), axis=1)
 
         return attributes.flatten()  # flatten to single list
 

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -42,7 +42,7 @@ class PointCloud(object):
         path: Path,
         points: np.ndarray,
         colors: Optional[np.ndarray] = None,
-        labels: Optional[npt.NDArray[np.int8]] = None,
+        segmentation_labels: Optional[npt.NDArray[np.int8]] = None,
         label_definition: Optional[Dict[str, int]] = None,
         init_translation: Optional[Tuple[float, float, float]] = None,
         init_rotation: Optional[Tuple[float, float, float]] = None,
@@ -55,7 +55,7 @@ class PointCloud(object):
 
         self.labels = self.label_definition = self.label_color_map = None
         if self.SEGMENTATION:
-            self.labels = labels
+            self.labels = segmentation_labels
             self.label_definition = label_definition
             self.label_color_map = get_distinct_colors(len(label_definition))
             self.mix_ratio = config.getfloat("POINTCLOUD", "label_color_mix_ratio")
@@ -324,11 +324,5 @@ class PointCloud(object):
         print_column(["Point Cloud Minimums:", np.round(self.pcd_mins, 2)])
         print_column(["Point Cloud Maximums:", np.round(self.pcd_maxs, 2)])
         print_column(
-            ["Initial Translation:", np.round(self.init_translation, 2)],
+            ["Initial Translation:", np.round(self.init_translation, 2)], last=True
         )
-        if self.SEGMENTATION:
-            counter = self.label_counts
-            print_column(["Label defintion:", "Count"])
-            for k, v in counter.items():
-                print_column([f"`{k}`", green(v)])
-        print_column([], last=True)

--- a/labelCloud/resources/interfaces/interface.ui
+++ b/labelCloud/resources/interfaces/interface.ui
@@ -1545,6 +1545,7 @@
     <addaction name="action_showorientation"/>
     <addaction name="action_saveperspective"/>
     <addaction name="action_alignpcd"/>
+    <addaction name="action_colorwithlabel"/>
     <addaction name="action_changesettings"/>
    </widget>
    <addaction name="menuFile"/>
@@ -1575,7 +1576,18 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Z-Rotation Only Mode</string>
+    <string>Z-Rotation Only Mode1223</string>
+   </property>
+  </action>
+  <action name="action_colorwithlabel">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Color with labels</string>
    </property>
   </action>
   <action name="action_deletealllabels">

--- a/labelCloud/resources/interfaces/interface.ui
+++ b/labelCloud/resources/interfaces/interface.ui
@@ -1583,9 +1583,6 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
    <property name="text">
     <string>Color with labels</string>
    </property>

--- a/labelCloud/resources/interfaces/interface.ui
+++ b/labelCloud/resources/interfaces/interface.ui
@@ -1576,7 +1576,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Z-Rotation Only Mode1223</string>
+    <string>Z-Rotation Only Mode</string>
    </property>
   </action>
   <action name="action_colorwithlabel">

--- a/labelCloud/tests/unit/test_color.py
+++ b/labelCloud/tests/unit/test_color.py
@@ -1,0 +1,22 @@
+import numpy as np
+from labelCloud.utils.color import colorize_points_with_height, get_distinct_colors
+
+
+def test_get_distinct_colors() -> None:
+    num_colors = 17
+    colors = get_distinct_colors(num_colors)
+    assert colors.dtype == np.float32
+    assert colors.shape == (num_colors, 3)
+    assert 0 <= colors.max() <= 1
+
+
+def test_colorize_points_with_height() -> None:
+    num_points = 900
+    points = np.random.uniform(low=0, high=10, size=(num_points, 3))
+    z_min = points[:, 2].min()
+    z_max = points[:, 2].max()
+
+    colors = colorize_points_with_height(points, z_min, z_max)
+    assert colors.dtype == np.float32
+    assert colors.shape == (num_points, 3)
+    assert 0 <= colors.max() <= 1

--- a/labelCloud/utils/color.py
+++ b/labelCloud/utils/color.py
@@ -1,0 +1,27 @@
+import colorsys
+
+import numpy as np
+import numpy.typing as npt
+
+
+def get_distinct_colors(n: int) -> npt.NDArray[np.float32]:
+    """generate visualy distinct colors
+    Args:
+        n (int): number of colors
+    Returns:
+        npt.NDArray[np.float32]: n x 3 (rgb) values between 0 and 1
+    """
+    hue_partition = 1.0 / (n + 1)
+    return np.vstack(
+        [
+            np.array(
+                colorsys.hsv_to_rgb(
+                    hue_partition * value,
+                    1.0 - (value % 2) * 0.5,
+                    1.0 - (value % 3) * 0.1,
+                ),
+                dtype=np.float32,
+            )
+            for value in range(0, n)
+        ]
+    )

--- a/labelCloud/utils/color.py
+++ b/labelCloud/utils/color.py
@@ -2,6 +2,7 @@ import colorsys
 
 import numpy as np
 import numpy.typing as npt
+import pkg_resources
 
 
 def get_distinct_colors(n: int) -> npt.NDArray[np.float32]:
@@ -19,9 +20,22 @@ def get_distinct_colors(n: int) -> npt.NDArray[np.float32]:
                     hue_partition * value,
                     1.0 - (value % 2) * 0.5,
                     1.0 - (value % 3) * 0.1,
-                ),
-                dtype=np.float32,
+                )
             )
             for value in range(0, n)
         ]
+    ).astype(np.float32)
+
+
+def colorize_points_with_height(
+    points: np.ndarray, z_min: float, z_max: float
+) -> np.ndarray:
+    palette = np.loadtxt(
+        pkg_resources.resource_filename("labelCloud.resources", "rocket-palette.txt")
     )
+    palette_len = len(palette) - 1
+
+    colors = np.zeros(points.shape)
+    for ind, height in enumerate(points[:, 2]):
+        colors[ind] = palette[round((height - z_min) / (z_max - z_min) * palette_len)]
+    return colors.astype(np.float32)

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -56,6 +56,10 @@ def set_zrotation_only(state: bool) -> None:
     config.set("USER_INTERFACE", "z_rotation_only", str(state))
 
 
+def set_color_with_label(state: bool) -> None:
+    config.set("POINTCLOUD", "color_with_label", str(state))
+
+
 def set_keep_perspective(state: bool) -> None:
     config.set("USER_INTERFACE", "keep_perspective", str(state))
 
@@ -130,6 +134,9 @@ class GUI(QtWidgets.QMainWindow):
         # Settings
         self.action_zrotation = self.findChild(
             QtWidgets.QAction, "action_zrotationonly"
+        )
+        self.action_colorwithlabel = self.findChild(
+            QtWidgets.QAction, "action_colorwithlabel"
         )
         self.action_showfloor = self.findChild(QtWidgets.QAction, "action_showfloor")
         self.action_showorientation = self.findChild(
@@ -357,6 +364,7 @@ class GUI(QtWidgets.QMainWindow):
             self.controller.bbox_controller.reset
         )
         self.action_zrotation.toggled.connect(set_zrotation_only)
+        self.action_colorwithlabel.toggled.connect(set_color_with_label)
         self.action_showfloor.toggled.connect(set_floor_visibility)
         self.action_showorientation.toggled.connect(set_orientation_visibility)
         self.action_saveperspective.toggled.connect(set_keep_perspective)

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -135,7 +135,7 @@ class GUI(QtWidgets.QMainWindow):
         self.action_zrotation = self.findChild(
             QtWidgets.QAction, "action_zrotationonly"
         )
-        self.action_colorwithlabel = self.findChild(
+        self.action_colorwithlabel: QtWidgets.QAction = self.findChild(
             QtWidgets.QAction, "action_colorwithlabel"
         )
         self.action_showfloor = self.findChild(QtWidgets.QAction, "action_showfloor")
@@ -382,6 +382,9 @@ class GUI(QtWidgets.QMainWindow):
         )
         self.action_zrotation.setChecked(
             config.getboolean("USER_INTERFACE", "z_rotation_only")
+        )
+        self.action_colorwithlabel.setChecked(
+            config.getboolean("POINTCLOUD", "color_with_label")
         )
 
     # Collect, filter and forward events to viewer

--- a/labelCloud/view/viewer.py
+++ b/labelCloud/view/viewer.py
@@ -65,7 +65,7 @@ class GLWidget(QtOpenGL.QGLWidget):
         logging.info("Intialized widget.")
 
         # Must be written again, due to buffer clearing
-        self.pcd_manager.pointcloud.write_vbo()
+        self.pcd_manager.pointcloud.create_buffers()
 
     def resizeGL(self, width, height) -> None:
         logging.info("Resized widget.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy~=1.21.4
 open3d~=0.14.1
 PyOpenGL~=3.1.5
-PyQt5~=5.14.1
+PyQt5~=5.15.7
 pytest~=7.1.1
 pytest-qt~=4.0.2
+PyOpenGL-accelerate~=3.1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     open3d
     PyOpenGL
     PyQt5
+    PyOpenGL-accelerate
 python_requires = >=3.6
 
 [options.entry_points]


### PR DESCRIPTION
This PR introduces the functionality of blending point colors with label colors, which generated automatically based on a helper function.

Specifically,
1. Three more config options and UI changes:
- `MODE.segmentation` (bool): whether or not to read segmentation labels and enable the blending effect
- `POINTCLOUD.color_with_label` (bool): whether or not to blend the point colors with label colors, this is also made configurable/ changable in the GUI.
- `POINTCLOUD.label_color_mix_ratio`: final_color = ratio * label_color + (1-ratio) * rgb_color

2. Change the vertex buffer from 1 to 3:
- 3 buffers for XYZ, original RGB and blended RGB
- change the `PointCloud.draw_pointcloud` so it's changed the point colors according to `POINTCLOUD.color_with_label`
- rename and make it part of `PointCloud` from `create_buffer` to `PointCloud.create_buffers`
- simplify the `create_buffers` logic - decide the `buffersize` and `bufferdata` directly based on numpy/openGL implementation

3. `color` module
- Move the `colorize_colorless` to `color` module and rename it
- Introduce a new `get_distinct_color` function to generate visually distinct colors - this can be made optional when the color schema is defined by the users
- unit test coverages

4. Dependencies
- bump `PyQt5` from 5.14.1 to 5.15.7
- install `PyOpenGL-accelerate~=3.1.5` for leveraging better GPU acceleration
\
<img width="924" alt="image" src="https://user-images.githubusercontent.com/60384727/187025680-a05b3cc4-5d18-45a2-982c-1125c180bde1.png">

