### PR TITLE
Fix integration tests

### DIFF
--- a/labelCloud/tests/integration/test_gui.py
+++ b/labelCloud/tests/integration/test_gui.py
@@ -1,12 +1,17 @@
 import logging
 import os
+from typing import Tuple
 
-from labelCloud.control.config_manager import config
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QAbstractSlider
 
+from labelCloud.control.config_manager import config
+from labelCloud.control.controller import Controller
+from labelCloud.model.bbox import BBox
+from labelCloud.view.gui import GUI
 
-def test_gui(qtbot, startup_pyqt):
+
+def test_gui(qtbot, startup_pyqt: Tuple[GUI, Controller]):
     view, controller = startup_pyqt
 
     assert len(controller.pcd_manager.pcds) > 0
@@ -17,15 +22,17 @@ def test_gui(qtbot, startup_pyqt):
     bbox = controller.bbox_controller.bboxes[0]
     bbox.center = (0, 0, 0)
     controller.bbox_controller.set_active_bbox(0)
-    qtbot.mouseClick(view.button_right, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_up, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_backward, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_right, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_up, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_backward, QtCore.Qt.LeftButton, delay=0)
     assert bbox.center == (0.03, 0.03, 0.03)
 
     view.close()
 
 
-def test_bbox_control_with_buttons(qtbot, startup_pyqt, bbox):
+def test_bbox_control_with_buttons(
+    qtbot, startup_pyqt: Tuple[GUI, Controller], bbox: BBox
+):
     view, controller = startup_pyqt
 
     # Prepare test bounding box
@@ -35,34 +42,36 @@ def test_bbox_control_with_buttons(qtbot, startup_pyqt, bbox):
 
     # Translation
     translation_step = config.getfloat("LABEL", "std_translation")
-    qtbot.mouseClick(view.button_right, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_up, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_backward, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_right, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_up, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_backward, QtCore.Qt.LeftButton, delay=0)
     assert bbox.center == (translation_step, translation_step, translation_step)
-    qtbot.mouseClick(view.button_left, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_down, QtCore.Qt.LeftButton, delay=0)
-    qtbot.mouseClick(view.button_forward, QtCore.Qt.LeftButton)
+    qtbot.mouseClick(view.button_bbox_left, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_down, QtCore.Qt.LeftButton, delay=0)
+    qtbot.mouseClick(view.button_bbox_forward, QtCore.Qt.LeftButton)
     logging.info("BBOX: %s" % [str(c) for c in bbox.get_center()])
     assert bbox.center == (0.00, 0.00, 0.00)
 
     # Scaling
     scaling_step = config.getfloat("LABEL", "std_scaling")
-    qtbot.mouseClick(view.button_incr_dim, QtCore.Qt.LeftButton)
+    qtbot.mouseClick(view.button_bbox_increase_dimension, QtCore.Qt.LeftButton)
     assert bbox.length == old_length + scaling_step
     assert bbox.width == old_width / old_length * bbox.length
     assert bbox.height == old_height / old_length * bbox.length
 
     # Rotation
     # TODO: Make dial configureable?
-    view.dial_zrotation.triggerAction(QAbstractSlider.SliderSingleStepAdd)
+    view.dial_bbox_z_rotation.triggerAction(QAbstractSlider.SliderSingleStepAdd)
     assert bbox.z_rotation == 1
-    view.dial_zrotation.triggerAction(QAbstractSlider.SliderPageStepAdd)
+    view.dial_bbox_z_rotation.triggerAction(QAbstractSlider.SliderPageStepAdd)
     assert bbox.z_rotation == 11
 
     view.close()
 
 
-def test_bbox_control_with_keyboard(qtbot, startup_pyqt, qapp, bbox):
+def test_bbox_control_with_keyboard(
+    qtbot, startup_pyqt: Tuple[GUI, Controller], qapp, bbox: BBox
+):
     view, controller = startup_pyqt
 
     # Prepare test bounding box

--- a/labelCloud/tests/integration/test_labeling.py
+++ b/labelCloud/tests/integration/test_labeling.py
@@ -1,17 +1,22 @@
-import pytest
-from labelCloud.control.config_manager import config
-from labelCloud.model.bbox import BBox
+from typing import Tuple
+
 from PyQt5 import QtCore
 from PyQt5.QtCore import QPoint
 
+import pytest
+from labelCloud.control.config_manager import config
+from labelCloud.control.controller import Controller
+from labelCloud.model.bbox import BBox
+from labelCloud.view.gui import GUI
 
-def test_picking_mode(qtbot, startup_pyqt):
+
+def test_picking_mode(qtbot, startup_pyqt: Tuple[GUI, Controller]):
     view, control = startup_pyqt
     control.bbox_controller.bboxes = []
 
-    qtbot.mouseClick(view.button_activate_picking, QtCore.Qt.LeftButton, delay=1000)
+    qtbot.mouseClick(view.button_pick_bbox, QtCore.Qt.LeftButton, delay=1000)
     qtbot.mouseClick(
-        view.glWidget, QtCore.Qt.LeftButton, pos=QPoint(500, 500), delay=1000
+        view.gl_widget, QtCore.Qt.LeftButton, pos=QPoint(500, 500), delay=1000
     )
 
     assert len(control.bbox_controller.bboxes) == 1
@@ -26,23 +31,23 @@ def test_picking_mode(qtbot, startup_pyqt):
     assert new_bbox.z_rotation == new_bbox.y_rotation == new_bbox.x_rotation == 0
 
 
-def test_spanning_mode(qtbot, startup_pyqt):
+def test_spanning_mode(qtbot, startup_pyqt: Tuple[GUI, Controller]):
     view, control = startup_pyqt
     control.bbox_controller.bboxes = []
     config.set("USER_INTERFACE", "z_rotation_only", "True")
 
-    qtbot.mouseClick(view.button_activate_spanning, QtCore.Qt.LeftButton, delay=10)
+    qtbot.mouseClick(view.button_span_bbox, QtCore.Qt.LeftButton, delay=10)
     qtbot.mouseClick(
-        view.glWidget, QtCore.Qt.LeftButton, pos=QPoint(431, 475), delay=20
+        view.gl_widget, QtCore.Qt.LeftButton, pos=QPoint(431, 475), delay=20
     )
     qtbot.mouseClick(
-        view.glWidget, QtCore.Qt.LeftButton, pos=QPoint(506, 367), delay=20
+        view.gl_widget, QtCore.Qt.LeftButton, pos=QPoint(506, 367), delay=20
     )
     qtbot.mouseClick(
-        view.glWidget, QtCore.Qt.LeftButton, pos=QPoint(572, 439), delay=20
+        view.gl_widget, QtCore.Qt.LeftButton, pos=QPoint(572, 439), delay=20
     )
     qtbot.mouseClick(
-        view.glWidget, QtCore.Qt.LeftButton, pos=QPoint(607, 556), delay=20
+        view.gl_widget, QtCore.Qt.LeftButton, pos=QPoint(607, 556), delay=20
     )
 
     assert len(control.bbox_controller.bboxes) == 1


### PR DESCRIPTION
 - adapt integration tests to changed namings

Relates: #93

Forgot to also apply the renamed attributes to the integration. Unfortunately the integration tests stopped working in the Github pipeline some months ago. I assume Github changes sth. in the container setup.