### PR TITLE
Use dropdown list instead of editbox for box classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 !labelCloud/resources/examples/exemplary.ply
 !labelCloud/resources/examples/exemplary.json
 !labelCloud/resources/labelCloud_icon.pcd
-!labels/segmentation/schema/label_definition.json
+!labels/schema/label_definition.json
 !labels/segmentation/exemplary.bin
 
 # ---------------------------------------------------------------------------- #

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 [MODE]
-segmentation = true
+segmentation = false
 
 [FILE]
 ; source of point clouds
@@ -28,8 +28,6 @@ label_color_mix_ratio = 0.3
 [LABEL]
 ; format for exporting labels. choose from (vertices, centroid_rel, centroid_abs, kitti)
 label_format = centroid_abs
-; list of object classes for autocompletion in the text field
-object_classes = cart, box
 ; default object class for new bounding boxes
 std_object_class = cart
 ; number of decimal places for exporting the bounding box parameter.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -47,7 +47,6 @@ The following parameters can be changed:
 |         `std_zoom`          | Standard step for zooming (with mouse scroll).                                                  |       *0.0025*        |
 |         **[LABEL]**         |
 |       `label_format`        | Format for exporting labels, choose from `vertices`, `centroid_rel`, `centroid_abs` or `kitti`. |    *centroid_abs*     |
-|      `object_classes`       | List of object classes for autocompletion in the class text field.                              | *class1, class2, ...* |
 |     `std_object_class`      | Default object class for new bounding boxes.                                                    |    *default_class*    |
 |     `export_precision`      | Number of decimal places for exporting the bounding box parameters.                             |          *8*          |
 |  `std_boundingbox_length`   | Default length of the bounding box (for picking mode).                                          |        *0.75*         |

--- a/labelCloud/control/bbox_controller.py
+++ b/labelCloud/control/bbox_controller.py
@@ -84,6 +84,9 @@ class BoundingBoxController(object):
         if isinstance(bbox, BBox):
             self.bboxes.append(bbox)
             self.set_active_bbox(self.bboxes.index(bbox))
+            self.view.current_class_dropdown.setCurrentText(
+                self.get_active_bbox().classname
+            )
             self.view.status_manager.update_status(
                 "Bounding Box added, it can now be corrected.", Mode.CORRECTION
             )
@@ -306,9 +309,11 @@ class BoundingBoxController(object):
 
     def update_curr_class(self) -> None:
         if self.has_active_bbox():
-            self.view.update_curr_class_edit()
+            self.view.current_class_dropdown.setCurrentText(
+                self.get_active_bbox().classname
+            )
         else:
-            self.view.update_curr_class_edit(force="")
+            self.view.controller.pcd_manager.populate_class_dropdown()
 
     def update_label_list(self) -> None:
         """Updates the list of drawn labels and highlights the active label.

--- a/labelCloud/control/bbox_controller.py
+++ b/labelCloud/control/bbox_controller.py
@@ -85,7 +85,7 @@ class BoundingBoxController(object):
             self.bboxes.append(bbox)
             self.set_active_bbox(self.bboxes.index(bbox))
             self.view.current_class_dropdown.setCurrentText(
-                self.get_active_bbox().classname
+                self.get_active_bbox().classname  # type: ignore
             )
             self.view.status_manager.update_status(
                 "Bounding Box added, it can now be corrected.", Mode.CORRECTION
@@ -310,7 +310,7 @@ class BoundingBoxController(object):
     def update_curr_class(self) -> None:
         if self.has_active_bbox():
             self.view.current_class_dropdown.setCurrentText(
-                self.get_active_bbox().classname
+                self.get_active_bbox().classname  # type: ignore
             )
         else:
             self.view.controller.pcd_manager.populate_class_dropdown()

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -247,8 +247,13 @@ class PointCloudManger(object):
                 center=(0, 0, 0),
             )
 
+        points, colors = Open3DHandler().to_point_cloud(o3d_pointcloud)
         self.pointcloud = PointCloud(
-            self.pcd_path, *Open3DHandler().to_point_cloud(o3d_pointcloud)
+            self.pcd_path,
+            points,
+            self.pointcloud.label_definition,
+            colors,
+            self.pointcloud.labels,
         )
         self.pointcloud.to_file()
 

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -7,10 +7,9 @@ from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
-import pkg_resources
-
 import numpy as np
 import open3d as o3d
+import pkg_resources
 
 from ..definitions.types import Point3D
 from ..io.pointclouds import BasePointCloudHandler, Open3DHandler
@@ -41,7 +40,9 @@ class PointCloudManger(object):
 
         # Point cloud control
         self.pointcloud: Optional[PointCloud] = None
-        self.collected_object_classes: Set[str] = set()
+        self.collected_object_classes: Set[
+            str
+        ] = set()  # TODO: this should integrate with the new label definition setup.
         self.saved_perspective: Optional[Perspective] = None
 
     @property
@@ -134,6 +135,13 @@ class PointCloudManger(object):
         else:
             raise Exception("No point cloud left for loading!")
 
+    def populate_class_dropdown(self):
+        # Add point label list
+        print(self.pointcloud.points)
+        self.view.current_class_dropdown.clear()
+        for key in self.pointcloud.label_definition:
+            self.view.current_class_dropdown.addItem(key)
+
     def get_labels_from_file(self) -> List[BBox]:
         bboxes = self.label_manager.import_labels(self.pcd_path)
         logging.info(green("Loaded %s bboxes!" % len(bboxes)))
@@ -150,8 +158,6 @@ class PointCloudManger(object):
             self.collected_object_classes.update(
                 {bbox.get_classname() for bbox in bboxes}
             )
-            self.view.update_label_completer(self.collected_object_classes)
-            self.view.update_default_object_class_menu(self.collected_object_classes)
         else:
             logging.warning("No point clouds to save labels for!")
 

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -231,7 +231,7 @@ class PointCloudManger(object):
         rotation_matrix = o3d.geometry.get_rotation_matrix_from_axis_angle(
             np.multiply(axis, angle)
         )
-        o3d_pointcloud = Open3DHandler().to_open3d_point_cloud(self.pointcloud)
+        o3d_pointcloud = Open3DHandler.to_open3d_point_cloud(self.pointcloud)
         o3d_pointcloud.rotate(rotation_matrix, center=tuple(rotation_point))
         o3d_pointcloud.translate([0, 0, -rotation_point[2]])
         logging.info("Rotating point cloud...")
@@ -247,7 +247,7 @@ class PointCloudManger(object):
                 center=(0, 0, 0),
             )
 
-        points, colors = Open3DHandler().to_point_cloud(o3d_pointcloud)
+        points, colors = Open3DHandler.to_point_cloud(o3d_pointcloud)
         self.pointcloud = PointCloud(
             self.pcd_path,
             points,

--- a/labelCloud/io/__init__.py
+++ b/labelCloud/io/__init__.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def read_label_definition(label_definition_path: Path) -> Dict[str, int]:
+    with open(label_definition_path, "r") as f:
+        label_definition: Dict[str, int] = json.loads(f.read())
+        assert len(label_definition) > 0
+    return label_definition

--- a/labelCloud/io/pointclouds/open3d.py
+++ b/labelCloud/io/pointclouds/open3d.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
-
 import open3d as o3d
 
 from . import BasePointCloudHandler
@@ -18,17 +17,17 @@ class Open3DHandler(BasePointCloudHandler):
     def __init__(self) -> None:
         super().__init__()
 
+    @staticmethod
     def to_point_cloud(
-        self, pointcloud: o3d.geometry.PointCloud
+        pointcloud: o3d.geometry.PointCloud,
     ) -> Tuple[npt.NDArray, Optional[npt.NDArray]]:
         return (
             np.asarray(pointcloud.points).astype("float32"),
             np.asarray(pointcloud.colors).astype("float32"),
         )
 
-    def to_open3d_point_cloud(
-        self, pointcloud: "PointCloud"
-    ) -> o3d.geometry.PointCloud:
+    @staticmethod
+    def to_open3d_point_cloud(pointcloud: "PointCloud") -> o3d.geometry.PointCloud:
         o3d_pointcloud = o3d.geometry.PointCloud(
             o3d.utility.Vector3dVector(pointcloud.points)
         )

--- a/labelCloud/io/segmentations/base.py
+++ b/labelCloud/io/segmentations/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Type
+from typing import Dict, Set, Type
 
 import numpy as np
 import numpy.typing as npt
@@ -9,7 +9,7 @@ from ...utils.singleton import SingletonABCMeta
 
 
 class BaseSegmentationHandler(object, metaclass=SingletonABCMeta):
-    EXTENSIONS = set()  # should be set in subclasses
+    EXTENSIONS: Set[str] = set()  # should be set in subclasses
 
     def __init__(self, label_definition: Dict[str, int]) -> None:
         self.label_definition = label_definition
@@ -52,3 +52,6 @@ class BaseSegmentationHandler(object, metaclass=SingletonABCMeta):
         for subclass in cls.__subclasses__():
             if file_extension in subclass.EXTENSIONS:
                 return subclass
+        raise NotImplementedError(
+            f"{file_extension} is not supported for segmentation labels."
+        )

--- a/labelCloud/io/segmentations/base.py
+++ b/labelCloud/io/segmentations/base.py
@@ -1,7 +1,6 @@
-import json
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Tuple, Type
+from typing import Dict, Type
 
 import numpy as np
 import numpy.typing as npt
@@ -12,13 +11,8 @@ from ...utils.singleton import SingletonABCMeta
 class BaseSegmentationHandler(object, metaclass=SingletonABCMeta):
     EXTENSIONS = set()  # should be set in subclasses
 
-    def __init__(self, label_definition_path: Path) -> None:
-        self.read_label_definition(label_definition_path)
-
-    def read_label_definition(self, label_definition_path: Path) -> None:
-        with open(label_definition_path, "r") as f:
-            self.label_definition: Dict[str, int] = json.loads(f.read())
-            assert len(self.label_definition) > 0
+    def __init__(self, label_definition: Dict[str, int]) -> None:
+        self.label_definition = label_definition
 
     @property
     def default_label(self) -> int:
@@ -26,7 +20,7 @@ class BaseSegmentationHandler(object, metaclass=SingletonABCMeta):
 
     def read_or_create_labels(
         self, label_path: Path, num_points: int
-    ) -> Tuple[Dict[str, int], npt.NDArray[np.int8]]:
+    ) -> npt.NDArray[np.int8]:
         """Read labels per point and its schema"""
         if label_path.exists():
             labels = self._read_labels(label_path)
@@ -36,7 +30,7 @@ class BaseSegmentationHandler(object, metaclass=SingletonABCMeta):
                 )
         else:
             labels = self._create_labels(num_points)
-        return self.label_definition, labels
+        return labels
 
     def overwrite_labels(self, label_path: Path, labels: npt.NDArray[np.int8]) -> None:
         return self._write_labels(label_path, labels)

--- a/labelCloud/io/segmentations/numpy.py
+++ b/labelCloud/io/segmentations/numpy.py
@@ -12,7 +12,7 @@ class NumpySegmentationHandler(BaseSegmentationHandler):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    def _create_labels(self, num_points: int) -> npt.NDArray[np.int8]:
+    def _create_labels(self, num_points: int, *args, **kwargs) -> npt.NDArray[np.int8]:
         return np.ones(shape=(num_points,), dtype=np.int8) * self.default_label
 
     def _read_labels(self, label_path: Path) -> npt.NDArray[np.int8]:

--- a/labelCloud/resources/default_config.ini
+++ b/labelCloud/resources/default_config.ini
@@ -19,8 +19,6 @@ std_zoom = 0.0025
 [LABEL]
 ; format for exporting labels. choose from (vertices, centroid_rel, centroid_abs, kitti)
 label_format = centroid_abs
-; list of object classes for autocompletion in the text field
-object_classes = cart, box
 ; default object class for new bounding boxes
 std_object_class = cart
 ; number of decimal places for exporting the bounding box parameter.

--- a/labelCloud/resources/interfaces/interface.ui
+++ b/labelCloud/resources/interfaces/interface.ui
@@ -893,16 +893,16 @@
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLineEdit" name="edit_current_class">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
+          <item>
+              <widget class="QComboBox" name="current_class_dropdown">
+                  <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                      </sizepolicy>
+                  </property>
+              </widget>
+          </item>
          <item>
           <widget class="QLabel" name="current_bbox_title">
            <property name="sizePolicy">
@@ -1685,7 +1685,7 @@
   <tabstop>button_pick_bbox</tabstop>
   <tabstop>button_span_bbox</tabstop>
   <tabstop>button_save_label</tabstop>
-  <tabstop>edit_current_class</tabstop>
+  <tabstop>current_class_dropdown</tabstop>
   <tabstop>edit_pos_x</tabstop>
   <tabstop>edit_pos_y</tabstop>
   <tabstop>edit_pos_z</tabstop>

--- a/labelCloud/utils/color.py
+++ b/labelCloud/utils/color.py
@@ -29,7 +29,7 @@ def get_distinct_colors(n: int) -> npt.NDArray[np.float32]:
 
 def colorize_points_with_height(
     points: np.ndarray, z_min: float, z_max: float
-) -> np.ndarray:
+) -> npt.NDArray[np.float32]:
     palette = np.loadtxt(
         pkg_resources.resource_filename("labelCloud.resources", "rocket-palette.txt")
     )

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -11,7 +11,6 @@ from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
     QAction,
     QActionGroup,
-    QCompleter,
     QFileDialog,
     QInputDialog,
     QLabel,
@@ -86,6 +85,12 @@ STYLESHEET = """
         color: #FFF;
         border: none;
         background: rgb(0, 0, 255);
+        background: url("{icons_dir}/cube-outline_white.svg") center left no-repeat, #0000ff;
+    }}
+
+    QComboBox#current_class_dropdown::item::selected{{
+        border: 1px solid black;
+        color: red;
         background: url("{icons_dir}/cube-outline_white.svg") center left no-repeat, #0000ff;
     }}
 """
@@ -171,7 +176,7 @@ class GUI(QtWidgets.QMainWindow):
 
         # RIGHT PANEL
         self.label_list: QtWidgets.QListWidget
-        self.edit_current_class: QtWidgets.QLineEdit
+        self.current_class_dropdown: QtWidgets.QComboBox
         self.button_deselect_label: QtWidgets.QPushButton
         self.button_delete_label: QtWidgets.QPushButton
 
@@ -189,7 +194,6 @@ class GUI(QtWidgets.QMainWindow):
         self.edit_rot_z: QtWidgets.QLineEdit
 
         self.all_line_edits = [
-            self.edit_current_class,
             self.edit_pos_x,
             self.edit_pos_y,
             self.edit_pos_z,
@@ -210,8 +214,6 @@ class GUI(QtWidgets.QMainWindow):
         # Connect all events to functions
         self.connect_events()
         self.set_checkbox_states()  # tick in menu
-        self.update_label_completer()  # initialize label completer with classes in config
-        self.update_default_object_class_menu()
 
         # Start event cycle
         self.timer = QtCore.QTimer(self)
@@ -259,7 +261,7 @@ class GUI(QtWidgets.QMainWindow):
         )
 
         # LABELING CONTROL
-        self.edit_current_class.textChanged.connect(
+        self.current_class_dropdown.currentTextChanged.connect(
             self.controller.bbox_controller.set_classname
         )
         self.button_deselect_label.clicked.connect(
@@ -381,9 +383,9 @@ class GUI(QtWidgets.QMainWindow):
             self.controller.mouse_clicked(event)
             self.update_bbox_stats(self.controller.bbox_controller.get_active_bbox())
         elif (event.type() == QEvent.MouseButtonPress) and (
-            event_object != self.edit_current_class
+            event_object != self.current_class_dropdown
         ):
-            self.edit_current_class.clearFocus()
+            self.current_class_dropdown.clearFocus()
             self.update_bbox_stats(self.controller.bbox_controller.get_active_bbox())
         return False
 
@@ -456,19 +458,8 @@ class GUI(QtWidgets.QMainWindow):
     def update_progress(self, value) -> None:
         self.progressbar_pcds.setValue(value)
 
-    def update_curr_class_edit(self, force: str = None) -> None:
-        if force is not None:
-            self.edit_current_class.setText(force)
-        else:
-            bbox = self.controller.bbox_controller.get_active_bbox()
-            if bbox:
-                self.edit_current_class.setText(bbox.get_classname())
-
-    def update_label_completer(self, classnames=None) -> None:
-        if classnames is None:
-            classnames = set()
-        classnames.update(config.getlist("LABEL", "object_classes"))
-        self.edit_current_class.setCompleter(QCompleter(classnames))
+    def update_current_class_dropdown(self) -> None:
+        self.controller.pcd_manager.populate_class_dropdown()
 
     def update_bbox_stats(self, bbox) -> None:
         viewing_precision = config.getint("USER_INTERFACE", "viewing_precision")
@@ -572,24 +563,6 @@ class GUI(QtWidgets.QMainWindow):
                 path_to_folder
             )
             logging.info("Changed label folder to %s!" % path_to_folder)
-
-    def update_default_object_class_menu(self, new_classes: Set[str] = None) -> None:
-        object_classes = {
-            str(class_name) for class_name in config.getlist("LABEL", "object_classes")
-        }
-        object_classes.update(new_classes or [])
-        existing_classes = {
-            action.text() for action in self.actiongroup_default_class.actions()
-        }
-        for object_class in object_classes.difference(existing_classes):
-            action = self.actiongroup_default_class.addAction(
-                object_class
-            )  # TODO: Add limiter for number of classes
-            action.setCheckable(True)
-            if object_class == config.get("LABEL", "std_object_class"):
-                action.setChecked(True)
-
-        self.act_set_default_class.addActions(self.actiongroup_default_class.actions())
 
     def change_default_object_class(self, action: QAction) -> None:
         config.set("LABEL", "std_object_class", action.text())

--- a/labelCloud/view/settings_dialog.py
+++ b/labelCloud/view/settings_dialog.py
@@ -52,9 +52,6 @@ class SettingsDialog(QDialog):
             LabelManager.LABEL_FORMATS
         )  # TODO: Fix visualization
         self.comboBox_labelformat.setCurrentText(config.get("LABEL", "label_format"))
-        self.plainTextEdit_objectclasses.setPlainText(
-            config.get("LABEL", "object_classes")
-        )
         self.lineEdit_standardobjectclass.setText(
             config.get("LABEL", "std_object_class")
         )
@@ -124,9 +121,6 @@ class SettingsDialog(QDialog):
 
         # Label
         config["LABEL"]["label_format"] = self.comboBox_labelformat.currentText()
-        config["LABEL"][
-            "object_classes"
-        ] = self.plainTextEdit_objectclasses.toPlainText()
         config["LABEL"]["std_object_class"] = self.lineEdit_standardobjectclass.text()
         config["LABEL"]["export_precision"] = str(self.spinBox_exportprecision.value())
         config["LABEL"]["min_boundingbox_dimension"] = str(

--- a/labels/schema/label_definition.json
+++ b/labels/schema/label_definition.json
@@ -1,0 +1,7 @@
+{
+    "unassigned": 0,
+    "person": 1,
+    "cart": 2,
+    "wall": 3,
+    "floor": 4
+}

--- a/labels/segmentation/schema/label_definition.json
+++ b/labels/segmentation/schema/label_definition.json
@@ -1,7 +1,0 @@
-{
-    "unassigned": 0,
-    "person": 1,
-    "car": 2,
-    "wall": 3,
-    "floor": 4
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest~=7.1.2
 pytest-qt~=4.1.0
 
 # Development
-black~=22.1.0
+black~=22.3.0
 mypy~=0.971
 PyQt5-stubs~=5.15.6
 types-setuptools~=57.4.17


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60384727/189477109-09934dc6-a04d-41b2-9e9b-81aa1f26555d.png)

My original plan was to put this together with the PR that assigning box labels to point labels but I realise that it's a logically separated functionality, so I split it to this PR so it's easier to review component-by-component.

This PR replace the class edit box to class drop down box to force the user to have a restricted set of options when setting the box classes as well as the point classes. Because of the nature of it, the class definition in `config.ini` is removed. Ideally, `std_object_class` should be removed as well but because there is another [PR](https://github.com/ch-sa/labelCloud/pull/94) addressing that, it is retained for now.

The label_definition concept is therefore shared across two modes. This also paves the way for the label definition `setup` idea. 

Expected behaviours:
1. When a new point cloud is loaded, the dropdown list is populated with the definition in the schema/label_definition.json file
2. When a box is selected, the selected item in the dropdown list will change to the classname of the box
3. When a new box is created, it will change to the `std_object_class`