### PR TITLE
Add unknown label classes from loaded labels

### DIFF
--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -1,21 +1,21 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import numpy.typing as npt
 
 from ...control.config_manager import config
 from ...definitions.types import Color3f, LabelingMode
-from ...utils.color import hex_to_rgb, rgb_to_hex
+from ...utils.color import get_random_hex_color, hex_to_rgb, rgb_to_hex
 from ...utils.singleton import SingletonABCMeta
 
 
 @dataclass
 class ClassConfig:
-    name: str
     id: int
+    name: str
     color: Color3f
 
     @classmethod
@@ -78,6 +78,10 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
             lookup[c.id] = order
         return lookup
 
+    @property
+    def next_class_id(self) -> int:  # TODO: merge with welcome dialog?
+        return max(label_class.id for label_class in self.classes) + 1
+
     # GETTERS
 
     def get_classes(self) -> Dict[str, ClassConfig]:
@@ -106,4 +110,16 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
 
     def set_class_color(self, class_name: str, color: Color3f) -> None:
         self.get_class(class_name).color = color
+        self.save_config()
+
+    def add_class(
+        self, name: str, id: Optional[int] = None, color: Optional[Color3f] = None
+    ) -> None:
+        self.classes.append(
+            ClassConfig(
+                id=id or self.next_class_id,
+                name=name,
+                color=color or hex_to_rgb(get_random_hex_color()),
+            )
+        )
         self.save_config()

--- a/labelCloud/tests/integration/conftest.py
+++ b/labelCloud/tests/integration/conftest.py
@@ -1,10 +1,7 @@
 import logging
 import os
-import time
-from typing import Tuple
 
 import pytest
-from PyQt5 import QtCore
 
 from labelCloud.control.controller import Controller
 from labelCloud.model.bbox import BBox
@@ -39,5 +36,4 @@ def startup_pyqt(qtbot, qapp, monkeypatch):
 
 @pytest.fixture
 def bbox():
-
     return BBox(cx=0, cy=0, cz=0, length=3, width=2, height=1)

--- a/labelCloud/utils/color.py
+++ b/labelCloud/utils/color.py
@@ -1,4 +1,5 @@
 import colorsys
+import random
 from typing import List
 
 import numpy as np
@@ -30,6 +31,18 @@ def get_distinct_colors(n: int) -> List[str]:
     ).astype(np.float32)
 
     return [rgb_to_hex(color) for color in colors]
+
+
+DISTINCT_COLORS: List[str] = []
+
+
+def get_random_hex_color() -> str:
+    global DISTINCT_COLORS
+    if not DISTINCT_COLORS:
+        DISTINCT_COLORS = get_distinct_colors(25)
+        random.shuffle(DISTINCT_COLORS)
+
+    return DISTINCT_COLORS.pop()
 
 
 def colorize_points_with_height(

--- a/labels/schema/label_definition.json
+++ b/labels/schema/label_definition.json
@@ -1,7 +1,0 @@
-{
-    "unassigned": 0,
-    "person": 1,
-    "cart": 2,
-    "wall": 3,
-    "floor": 4
-}


### PR DESCRIPTION
This ensures backwards compatibility with old labelCloud versions and the label files that were generated with those.

Additionally this helps if the `_classes.json` was accidentally deleted.