### PR TITLE
Add label propagation

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -45,6 +45,8 @@ std_rotation = 0.5
 std_scaling = 0.03
 ; minimum value for the length, width and height of a bounding box
 min_boundingbox_dimension = 0.01
+; propagate labels to next point cloud if it has no labels yet
+propagate_labels = False
 
 [USER_INTERFACE]
 ; only allow z-rotation of bounding boxes. set false to also label x- & y-rotation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ The following parameters can be changed:
 |       `std_rotation`        | Standard step for rotating the bounding box (with key press).                                   |         *0.5*          |
 |        `std_scaling`        | Standard step for scaling the bounding box (with button press).                                 |         *0.03*         |
 | `min_boundingbox_dimension` | Minimum value for the length, width and height of a bounding box.                               |         *0.01*         |
+|     `propagate_labels`      | Copy all bounding boxes of the current point cloud to the next point cloud (only forward).      |        *False*         |
 |    **[USER_INTERFACE]**     |
 |      `z_rotation_only`      | Only allow z-rotation of bounding box; deactivate to also label x- & y-rotation.                |         *True*         |
 |        `show_floor`         | Visualizes the floor (x-y-plane) as a grid.                                                     |         *True*         |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,12 @@ labelCloud is a lightweight tool for labeling 3D bounding boxes in point clouds.
 It is written in Python and can be installed via `pip` (see [Setup](setup.md)).
 
 ## Labeling
-labelCloud supports two different ways of labeling (*picking* & *spanning*) as well as multiple mouse and keyboard options for subsequent correction.
+labelCloud supports two different ways of labeling (*picking* & *spanning*) as well as multiple
+mouse and keyboard options for subsequent correction.
 
 ![Screencast of the Labeling Methods](assets/screencast_small.gif)
-(There is also a [short YouTube-Video](https://www.youtube.com/watch?v=8GF9n1WeR8A) that introduces the tool.)
+(There is also a [short YouTube-Video](https://www.youtube.com/watch?v=8GF9n1WeR8A) that introduces
+the tool.)
 
 ### Picking Mode
 
@@ -24,16 +26,23 @@ labelCloud supports two different ways of labeling (*picking* & *spanning*) as w
 
 ### Correction
 
-* Use the buttons on the left-hand side or shortcuts to correct the *translation*, *dimension* and *rotation* of the bounding box
+* Use the buttons on the left-hand side or shortcuts to correct the *translation*, *dimension* and
+  *rotation* of the bounding box
 * Resize the bounding box by holding your cursor above one side and scrolling with the mouse wheel
 
 By default the x- and y-rotation of bounding boxes will be prohibited.
-For labeling **9 DoF-Bounding Boxes** deactivate `z-Rotation Only Mode` in the menu, settings or `config.ini` file.
-Now you will be free to rotate around all three axes.
+For labeling **9 DoF-Bounding Boxes** deactivate `z-Rotation Only Mode` in the menu, settings or
+`config.ini` file.
+Now you will be able to rotate around all three axes.
+
+If you have a point clouds with objects that keep their positions over multiple frames, you can
+activate the *Propagate Labels* feature in the Labels menu or `config.ini`.
 
 ## Import & Export Options
-labelCloud is built for a versatile use and aims at supporting all common point cloud file formats and label formats for storing 3D bounding boxes.
-The tool is designed to be easily adaptable to multiple use cases. To change the settings, simply edit the corresponding line in the `config.ini` (see [Configuration](configuration.md)) for a description of all parameters).
+labelCloud is built for a versatile use and aims at supporting all common point cloud file formats
+and label formats for storing 3D bounding boxes.
+The tool is designed to be easily adaptable to multiple use cases. To change the settings, simply
+edit the corresponding line in the `config.ini` (see [Configuration](configuration.md)) for a description of all parameters).
 
 ### Supported Point Cloud Formats
 
@@ -44,13 +53,13 @@ The tool is designed to be easily adaptable to multiple use cases. To change the
 
 ### Supported Label Formats
 
-| Label Format          | Description                                                                                                                                                    |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `centroid_rel`        | Centroid `[x, y, z]`; Dimensions `[length, width, height]`; <br> Relative Rotations as Euler angles in radians (-pi..+pi) `[yaw, pitch, roll]`                 |
-| `centroid_abs`        | Centroid `[x, y, z]`; Dimensions `[length, width, height]`; <br> Absolute Rotations as Euler angles in degrees (0..360°) `[yaw, pitch, roll]`                  |
-| `vertices`            | 8 Vertices of the bounding box each with `[x, y, z]` (see [Conventions](conventions.md) for order) |
-| `kitti`               | Centroid; Dimensions; z-Rotation (See [specification](https://github.com/bostondiditeam/kitti/blob/master/resources/devkit_object/readme.txt))                 |
-| `kitti_untransformed` | See above, but without transformations.                                                                                                                        |
+| Label Format          | Description                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `centroid_rel`        | Centroid `[x, y, z]`; Dimensions `[length, width, height]`; <br> Relative Rotations as Euler angles in radians (-pi..+pi) `[yaw, pitch, roll]` |
+| `centroid_abs`        | Centroid `[x, y, z]`; Dimensions `[length, width, height]`; <br> Absolute Rotations as Euler angles in degrees (0..360°) `[yaw, pitch, roll]`  |
+| `vertices`            | 8 Vertices of the bounding box each with `[x, y, z]` (see [Conventions](conventions.md) for order)                                             |
+| `kitti`               | Centroid; Dimensions; z-Rotation (See [specification](https://github.com/bostondiditeam/kitti/blob/master/resources/devkit_object/readme.txt)) |
+| `kitti_untransformed` | See above, but without transformations.                                                                                                        |
 
 You can easily create your own exporter by subclassing the abstract [BaseLabelFormat](https://github.com/ch-sa/labelCloud/blob/master/labelCloud/label_formats/base.py#L10).
 All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the positive x- to the negative y-axis!).
@@ -58,7 +67,8 @@ All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the pos
 
 
 ## Usage & Attribution
-When using the tool feel free to drop me a mail with feedback or a description of your use case (christoph.sager[at]tu-dresden.de).
+When using the tool feel free to drop me a mail with feedback or a description of your use case
+(christoph.sager[at]tu-dresden.de).
 If you are using the tool for a scientific project please consider citing our publications:
 
 
@@ -104,5 +114,10 @@ If you are using the tool for a scientific project please consider citing our pu
     ```
 
 ## Acknowledgment
-I would like to thank the [Robotron RCV-Team](https://www.robotron.de/rcv) for the support in the preparation and user evaluation of the software.
-The software was developed as part of my diploma thesis titled "labelCloud: Development of a Labeling Tool for 3D Object Detection in Point Clouds" at the [Chair for Business Informatics, especially Intelligent Systems](https://tu-dresden.de/bu/wirtschaft/winf/isd) of the TU Dresden. The ongoing research can be followed in our [project on ResearchGate](https://www.researchgate.net/project/Development-of-a-Point-Cloud-Labeling-Tool-to-Generate-Training-Data-for-3D-Object-Detection-and-6D-Pose-Estimation).
+I would like to thank the [Robotron RCV-Team](https://www.robotron.de/rcv) for the support in the
+preparation and user evaluation of the software.
+The software was developed as part of my diploma thesis titled "labelCloud: Development of a
+Labeling Tool for 3D Object Detection in Point Clouds" at the
+[Chair for Business Informatics, especially Intelligent Systems](https://tu-dresden.de/bu/wirtschaft/winf/isd)
+of the TU Dresden. The ongoing research can be followed in our
+[project on ResearchGate](https://www.researchgate.net/project/Development-of-a-Point-Cloud-Labeling-Tool-to-Generate-Training-Data-for-3D-Object-Detection-and-6D-Pose-Estimation).

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -64,9 +64,15 @@ class Controller:
         if save:
             self.save()
         if self.pcd_manager.pcds_left():
+            previous_bboxes = self.bbox_controller.bboxes
             self.pcd_manager.get_next_pcd()
             self.reset()
             self.bbox_controller.set_bboxes(self.pcd_manager.get_labels_from_file())
+
+            if not self.bbox_controller.bboxes and config.getboolean(
+                "LABEL", "propagate_labels"
+            ):
+                self.bbox_controller.set_bboxes(previous_bboxes)
         else:
             self.view.update_progress(len(self.pcd_manager.pcds))
             self.view.button_next_pcd.setEnabled(False)

--- a/labelCloud/resources/interfaces/interface.ui
+++ b/labelCloud/resources/interfaces/interface.ui
@@ -1546,12 +1546,18 @@
     <property name="title">
      <string>File</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="act_set_pcd_folder"/>
     <addaction name="act_set_label_folder"/>
    </widget>
    <widget class="QMenu" name="menuLabels">
     <property name="title">
      <string>Labels</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <widget class="QMenu" name="act_set_default_class">
      <property name="title">
@@ -1560,10 +1566,14 @@
     </widget>
     <addaction name="act_set_default_class"/>
     <addaction name="act_delete_all_labels"/>
+    <addaction name="act_propagate_labels"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
     <property name="title">
      <string>Settings</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <addaction name="act_z_rotation_only"/>
     <addaction name="act_show_floor"/>
@@ -1602,6 +1612,9 @@
    </property>
    <property name="text">
     <string>Z-Rotation Only Mode</string>
+   </property>
+   <property name="toolTip">
+    <string>Only allows bounding box rotation around the z-axis.</string>
    </property>
   </action>
   <action name="act_color_with_label">
@@ -1642,6 +1655,9 @@
    <property name="text">
     <string>Show Floor</string>
    </property>
+   <property name="toolTip">
+    <string>Shows a grid along the x-y-plane (z=0).</string>
+   </property>
   </action>
   <action name="act_show_orientation">
    <property name="checkable">
@@ -1664,6 +1680,10 @@
    <property name="text">
     <string>Keep Perspective</string>
    </property>
+   <property name="toolTip">
+    <string>Saves the last perspective and reuses it,
+when opening that point cloud again.</string>
+   </property>
   </action>
   <action name="act_align_pcd">
    <property name="checkable">
@@ -1675,6 +1695,9 @@
    <property name="text">
     <string>Align Point Cloud</string>
    </property>
+   <property name="toolTip">
+    <string>Transforms the point cloud so that the floor is the x-y-plane.</string>
+   </property>
   </action>
   <action name="act_change_settings">
    <property name="text">
@@ -1684,6 +1707,18 @@
   <action name="actiontest">
    <property name="text">
     <string>test</string>
+   </property>
+  </action>
+  <action name="act_propagate_labels">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Propagate Labels</string>
+   </property>
+   <property name="toolTip">
+    <string>Propagate Labels to the next Point Cloud
+if it does not have labels yet.</string>
    </property>
   </action>
  </widget>

--- a/labelCloud/resources/interfaces/settings_interface.ui
+++ b/labelCloud/resources/interfaces/settings_interface.ui
@@ -333,107 +333,7 @@ Bounding Box Parameter</string>
      <property name="rightMargin">
       <number>0</number>
      </property>
-     <item row="8" column="1" colspan="2">
-      <widget class="QCheckBox" name="checkBox_zrotationonly">
-       <property name="toolTip">
-        <string>Only allow z-rotation of bounding boxes. Deactivate to also label x- &amp; y-rotation.</string>
-       </property>
-       <property name="text">
-        <string>Z-Rotation-Only Mode (otherwise rotation around x, y and z)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_labelformat">
-       <property name="toolTip">
-        <string>Format for exporting labels.</string>
-       </property>
-       <property name="text">
-        <string>Label Format</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QLabel" name="label_stdbboxwidth">
-       <property name="toolTip">
-        <string>Default width of the bounding box (for picking mode).</string>
-       </property>
-       <property name="text">
-        <string>Standard Bounding Box Width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="2">
-      <widget class="QSpinBox" name="spinBox_exportprecision">
-       <property name="toolTip">
-        <string>Number of decimal places shown for the parameters of the active bounding box.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QLabel" name="label_stdbboxtranslation">
-       <property name="toolTip">
-        <string>Standard step for translating the bounding box (meter).</string>
-       </property>
-       <property name="text">
-        <string>Standard Translation Step</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QComboBox" name="comboBox_labelformat">
-       <property name="toolTip">
-        <string>Format for exporting labels.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="15" column="1">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>30</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="14" column="2">
-      <widget class="QDoubleSpinBox" name="doubleSpinBox_minbboxdimensions">
-       <property name="toolTip">
-        <string>Minimum value for the length, width and height of a bounding box.</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="singleStep">
-        <double>0.001000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QLabel" name="label_stdbboxrotation">
-       <property name="toolTip">
-        <string>Standard step for rotating the bounding box (degree).</string>
-       </property>
-       <property name="text">
-        <string>Standard Rotation Step</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QLineEdit" name="lineEdit_standardobjectclass">
-       <property name="toolTip">
-        <string>Default object class for new bounding boxes.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="2">
       <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxscaling">
        <property name="toolTip">
         <string>Standard step for scaling the bounding box.</string>
@@ -449,91 +349,53 @@ Bounding Box Parameter</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="2">
-      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxtranslation">
+     <item row="16" column="2">
+      <spacer name="verticalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="12" column="1">
+      <widget class="QLabel" name="label_stdbboxtranslation">
        <property name="toolTip">
         <string>Standard step for translating the bounding box (meter).</string>
        </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="maximum">
-        <double>500.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_stdbboxlength">
-       <property name="toolTip">
-        <string>Default length of the bounding box (for picking mode).</string>
-       </property>
        <property name="text">
-        <string>Standard Bounding Box Length</string>
+        <string>Standard Translation Step</string>
        </property>
       </widget>
      </item>
-     <item row="12" column="2">
-      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxrotation">
-       <property name="toolTip">
-        <string>Standard step for rotating the bounding box (degree).</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="maximum">
-        <double>364.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="1">
-      <widget class="QLabel" name="label_minbboxdimensions">
-       <property name="toolTip">
-        <string>Minimum value for the length, width and height of a bounding box.</string>
-       </property>
-       <property name="text">
-        <string>Min. Bounding Box Dimensions</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QPlainTextEdit" name="plainTextEdit_objectclasses">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_objectclasses">
        <property name="toolTip">
         <string>List of object classes for autocompletion in the text field.</string>
        </property>
-       <property name="sizeAdjustPolicy">
-        <enum>QAbstractScrollArea::AdjustToContents</enum>
+       <property name="text">
+        <string>Object Classes</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>
-     <item row="7" column="2">
-      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxheight">
+     <item row="10" column="2">
+      <widget class="QSpinBox" name="spinBox_exportprecision">
        <property name="toolTip">
-        <string>Default height of the bounding box (for picking mode).</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="maximum">
-        <double>500.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
+        <string>Number of decimal places shown for the parameters of the active bounding box.</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QLabel" name="label_exportprecision">
        <property name="toolTip">
         <string>Number of decimal places shown for the parameters of the active bounding box.</string>
@@ -559,42 +421,84 @@ Bounding Box Parameter</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
-      <widget class="QLabel" name="label_stdbboxscaling">
+     <item row="7" column="1">
+      <widget class="QLabel" name="label_stdbboxheight">
        <property name="toolTip">
-        <string>Standard step for scaling the bounding box.</string>
+        <string>Default height of the bounding box (for picking mode).</string>
        </property>
        <property name="text">
-        <string>Standard Scaling Step</string>
+        <string>Standard Bounding Box Height</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="label_standardobjectclass">
+     <item row="12" column="2">
+      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxtranslation">
+       <property name="toolTip">
+        <string>Standard step for translating the bounding box (meter).</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>500.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPlainTextEdit" name="plainTextEdit_objectclasses">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+        <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Default object class for new bounding boxes.</string>
+        <string>List of object classes for autocompletion in the text field.</string>
        </property>
-       <property name="text">
-        <string>Standard Object Class</string>
+       <property name="sizeAdjustPolicy">
+        <enum>QAbstractScrollArea::AdjustToContents</enum>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_objectclasses">
+     <item row="6" column="2">
+      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxwidth">
        <property name="toolTip">
-        <string>List of object classes for autocompletion in the text field.</string>
+        <string>Default width of the bounding box (for picking mode).</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>500.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_labelformat">
+       <property name="toolTip">
+        <string>Format for exporting labels.</string>
        </property>
        <property name="text">
-        <string>Object Classes</string>
+        <string>Label Format</string>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </widget>
+     </item>
+     <item row="15" column="2">
+      <widget class="QDoubleSpinBox" name="doubleSpinBox_minbboxdimensions">
+       <property name="toolTip">
+        <string>Minimum value for the length, width and height of a bounding box.</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="singleStep">
+        <double>0.001000000000000</double>
        </property>
       </widget>
      </item>
@@ -617,33 +521,69 @@ Bounding Box Parameter</string>
        </property>
       </widget>
      </item>
-     <item row="16" column="2">
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="locale">
-        <locale language="English" country="UnitedStates"/>
-       </property>
+     <item row="16" column="1">
+      <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Vertical</enum>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>30</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="2">
+      <widget class="QComboBox" name="comboBox_labelformat">
+       <property name="toolTip">
+        <string>Format for exporting labels.</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
-      <widget class="QLabel" name="label_stdbboxheight">
+     <item row="13" column="1">
+      <widget class="QLabel" name="label_stdbboxrotation">
        <property name="toolTip">
-        <string>Default height of the bounding box (for picking mode).</string>
+        <string>Standard step for rotating the bounding box (degree).</string>
        </property>
        <property name="text">
-        <string>Standard Bounding Box Height</string>
+        <string>Standard Rotation Step</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="2">
-      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxwidth">
+     <item row="13" column="2">
+      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxrotation">
+       <property name="toolTip">
+        <string>Standard step for rotating the bounding box (degree).</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>364.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="label_stdbboxwidth">
        <property name="toolTip">
         <string>Default width of the bounding box (for picking mode).</string>
+       </property>
+       <property name="text">
+        <string>Standard Bounding Box Width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="QDoubleSpinBox" name="doubleSpinBox_stdbboxheight">
+       <property name="toolTip">
+        <string>Default height of the bounding box (for picking mode).</string>
        </property>
        <property name="decimals">
         <number>3</number>
@@ -656,23 +596,83 @@ Bounding Box Parameter</string>
        </property>
       </widget>
      </item>
-     <item row="15" column="2">
-      <spacer name="verticalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+     <item row="14" column="1">
+      <widget class="QLabel" name="label_stdbboxscaling">
+       <property name="toolTip">
+        <string>Standard step for scaling the bounding box.</string>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
+       <property name="text">
+        <string>Standard Scaling Step</string>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
-     <item row="16" column="1">
+     <item row="5" column="1">
+      <widget class="QLabel" name="label_stdbboxlength">
+       <property name="toolTip">
+        <string>Default length of the bounding box (for picking mode).</string>
+       </property>
+       <property name="text">
+        <string>Standard Bounding Box Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="1">
+      <widget class="QLabel" name="label_minbboxdimensions">
+       <property name="toolTip">
+        <string>Minimum value for the length, width and height of a bounding box.</string>
+       </property>
+       <property name="text">
+        <string>Min. Bounding Box Dimensions</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1" colspan="2">
+      <widget class="QCheckBox" name="checkBox_zrotationonly">
+       <property name="toolTip">
+        <string>Only allow z-rotation of bounding boxes. Deactivate to also label x- &amp; y-rotation.</string>
+       </property>
+       <property name="text">
+        <string>Z-Rotation-Only Mode (otherwise rotation around x, y and z)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_standardobjectclass">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Default object class for new bounding boxes.</string>
+       </property>
+       <property name="text">
+        <string>Standard Object Class</string>
+       </property>
+      </widget>
+     </item>
+     <item row="17" column="2">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="locale">
+        <locale language="English" country="UnitedStates"/>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QLineEdit" name="lineEdit_standardobjectclass">
+       <property name="toolTip">
+        <string>Default object class for new bounding boxes.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="17" column="1">
       <widget class="QPushButton" name="reset_button">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -682,6 +682,13 @@ Bounding Box Parameter</string>
        </property>
        <property name="text">
         <string>Reset to Default</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1" colspan="2">
+      <widget class="QCheckBox" name="checkBox_propagatelabels">
+       <property name="text">
+        <string>Propagate Labels (copy all bounding boxes to the next point cloud)</string>
        </property>
       </widget>
      </item>

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -68,6 +68,10 @@ def set_keep_perspective(state: bool) -> None:
     config.set("USER_INTERFACE", "keep_perspective", str(state))
 
 
+def set_propagate_labels(state: bool) -> None:
+    config.set("LABEL", "propagate_labels", str(state))
+
+
 # CSS file paths need to be set dynamically
 STYLESHEET = """
     * {{
@@ -138,6 +142,7 @@ class GUI(QtWidgets.QMainWindow):
         self.act_delete_all_labels: QtWidgets.QAction
         self.act_set_default_class: QtWidgets.QMenu
         self.actiongroup_default_class = QActionGroup(self.act_set_default_class)
+        self.act_propagate_labels: QtWidgets.QAction
 
         # Settings
         self.act_z_rotation_only: QtWidgets.QAction
@@ -369,6 +374,7 @@ class GUI(QtWidgets.QMainWindow):
         self.act_delete_all_labels.triggered.connect(
             self.controller.bbox_controller.reset
         )
+        self.act_propagate_labels.toggled.connect(set_propagate_labels)
         self.act_z_rotation_only.toggled.connect(set_zrotation_only)
         self.act_color_with_label.toggled.connect(set_color_with_label)
         self.act_show_floor.toggled.connect(set_floor_visibility)
@@ -378,6 +384,9 @@ class GUI(QtWidgets.QMainWindow):
         self.act_change_settings.triggered.connect(self.show_settings_dialog)
 
     def set_checkbox_states(self) -> None:
+        self.act_propagate_labels.setChecked(
+            config.getboolean("LABEL", "propagate_labels")
+        )
         self.act_show_floor.setChecked(
             config.getboolean("USER_INTERFACE", "show_floor")
         )

--- a/labelCloud/view/settings_dialog.py
+++ b/labelCloud/view/settings_dialog.py
@@ -80,6 +80,9 @@ class SettingsDialog(QDialog):
         self.doubleSpinBox_stdbboxscaling.setValue(
             config.getfloat("LABEL", "std_scaling")
         )
+        self.checkBox_propagatelabels.setChecked(
+            config.getboolean("LABEL", "propagate_labels")
+        )
 
         # User Interface
         self.checkBox_zrotationonly.setChecked(
@@ -143,6 +146,9 @@ class SettingsDialog(QDialog):
             self.doubleSpinBox_stdbboxrotation.value()
         )
         config["LABEL"]["std_scaling"] = str(self.doubleSpinBox_stdbboxscaling.value())
+        config["LABEL"]["propagate_labels"] = str(
+            self.checkBox_propagatelabels.isChecked()
+        )
 
         # User Interface
         config["USER_INTERFACE"]["z_rotation_only"] = str(


### PR DESCRIPTION
 - add a feature to carry over labels to the next point cloud
 - can be activated via config and menu action
 - will only copy labels if the next point cloud has no bounding boxes so far

Closes: #120