### PR TITLE
Validate the data in StartupDialog and handle mismatched segmentation labels

### DIFF
--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -11,6 +11,7 @@ from ..utils import oglhelper
 from ..view.gui import GUI
 from .alignmode import AlignMode
 from .bbox_controller import BoundingBoxController
+from .config_manager import config
 from .drawing_manager import DrawingManager
 from .pcd_manager import PointCloudManger
 

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -11,7 +11,6 @@ from ..utils import oglhelper
 from ..view.gui import GUI
 from .alignmode import AlignMode
 from .bbox_controller import BoundingBoxController
-from .config_manager import config
 from .drawing_manager import DrawingManager
 from .pcd_manager import PointCloudManger
 

--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -108,6 +108,12 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
             )
             return hex_to_rgb("#FF0000")
 
+    def has_valid_default_class(self) -> bool:
+        for c in self.classes:
+            if c.id == self.default:
+                return True
+        return False
+
     def get_default_class_name(self) -> str:
         for c in self.classes:
             if c.id == self.default:

--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -29,6 +29,7 @@ class ClassConfig:
             "color": rgb_to_hex(self.color),
         }
 
+
 class LabelConfigException(Exception):
     pass
 
@@ -54,13 +55,12 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
             self.type = data["type"]
             self.format = data["format"]
         else:
-            self.classes = [ClassConfig("cart", 0, color=Color3f(1, 0 , 0))]
+            self.classes = [ClassConfig("cart", 0, color=Color3f(1, 0, 0))]
             self.default = 0
             self.type = LabelingMode.OBJECT_DETECTION
             self.format = ".bin"
         self._validate()
         self._loaded = True
-
 
     def save_config(self) -> None:
         self._validate()
@@ -108,10 +108,14 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
             )
             return hex_to_rgb("#FF0000")
 
-    def get_default_class_name(self) -> Optional[str]:
+    def get_default_class_name(self) -> str:
         for c in self.classes:
             if c.id == self.default:
                 return c.name
+        raise LabelConfigException(
+            f"Default class id `{self.default}` doesn't present in the class list."
+        )
+
     # SETTERS
 
     def set_default_class(self, class_name: str) -> None:
@@ -125,11 +129,10 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
     # VALIDATION
     def _validate(self) -> None:
         # validate the default id presents in the classes
-        if self.get_default_class_name() is None:
-            raise LabelConfigException(f"Default class id `{self.default}` doesn't present in the class list.")
+        self.get_default_class_name()
         # validate the ids are unique
         if len({c.id for c in self.classes}) != self.nb_of_classes:
             raise LabelConfigException("Class ids are not unique.")
 
-        #TODO: validate the format against the mode
-        #TODO: validate the names are not empty
+        # TODO: validate the format against the mode
+        # TODO: validate the names are not empty

--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -131,7 +131,7 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
             if c.id == self.default:
                 return c.name
         raise DefaultIdMismatchException(
-            f"Default class id `{self.default}` doesn't present in the class list."
+            f"Default class id `{self.default}` is missing in the class list."
         )
 
     # SETTERS

--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import numpy as np
 import numpy.typing as npt
@@ -10,6 +10,12 @@ from ...control.config_manager import config
 from ...definitions.types import Color3f, LabelingMode
 from ...utils.color import hex_to_rgb, rgb_to_hex
 from ...utils.singleton import SingletonABCMeta
+from .exceptions import (
+    DefaultIdMismatchException,
+    LabelClassNameEmpty,
+    LabelIdsNotUniqueException,
+    ZeroLabelException,
+)
 
 
 @dataclass
@@ -28,22 +34,6 @@ class ClassConfig:
             "id": self.id,
             "color": rgb_to_hex(self.color),
         }
-
-
-class ZeroLabelException(Exception):
-    pass
-
-
-class LabelIdsNotUniqueException(Exception):
-    pass
-
-
-class DefaultIdMismatchException(Exception):
-    pass
-
-
-class LabelClassNameEmpty(Exception):
-    pass
 
 
 class LabelConfig(object, metaclass=SingletonABCMeta):

--- a/labelCloud/io/labels/exceptions.py
+++ b/labelCloud/io/labels/exceptions.py
@@ -1,0 +1,14 @@
+class ZeroLabelException(Exception):
+    pass
+
+
+class LabelIdsNotUniqueException(Exception):
+    pass
+
+
+class DefaultIdMismatchException(Exception):
+    pass
+
+
+class LabelClassNameEmpty(Exception):
+    pass

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -41,13 +41,17 @@ def consecutive(data: npt.NDArray[np.int64], stepsize=1) -> List[npt.NDArray[np.
     """Split an 1-d array of integers to a list of 1-d array where the elements are consecutive"""
     return np.split(data, np.where(np.diff(data) != stepsize)[0] + 1)
 
-def validate_segmentation_label(label_config: LabelConfig, labels: npt.NDArray[np.int8]) -> None:
+
+def validate_segmentation_label(
+    label_config: LabelConfig, labels: npt.NDArray[np.int8]
+) -> None:
     unique_label_ids = set(np.unique(labels))
     unique_class_ids = set(c.id for c in label_config.classes)
     if unique_class_ids != unique_label_ids:
         # TODO: define the fallback strategy
         # Ask users if they want to overwrite the labels with default or not.
         raise Exception("Segmentation labels don't match with the label config.")
+
 
 class PointCloud(object):
     def __init__(

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -41,6 +41,13 @@ def consecutive(data: npt.NDArray[np.int64], stepsize=1) -> List[npt.NDArray[np.
     """Split an 1-d array of integers to a list of 1-d array where the elements are consecutive"""
     return np.split(data, np.where(np.diff(data) != stepsize)[0] + 1)
 
+def validate_segmentation_label(label_config: LabelConfig, labels: npt.NDArray[np.int8]) -> None:
+    unique_label_ids = set(np.unique(labels))
+    unique_class_ids = set(c.id for c in label_config.classes)
+    if unique_class_ids != unique_label_ids:
+        # TODO: define the fallback strategy
+        # Ask users if they want to overwrite the labels with default or not.
+        raise Exception("Segmentation labels don't match with the label config.")
 
 class PointCloud(object):
     def __init__(
@@ -142,6 +149,8 @@ class PointCloud(object):
             label_path.suffix
         )()
         assert self.labels is not None
+        validate_segmentation_label(LabelConfig(), self.labels)
+
         seg_handler.overwrite_labels(label_path=label_path, labels=self.labels)
         logging.info(f"Writing segmentation labels to {label_path}")
 
@@ -171,6 +180,7 @@ class PointCloud(object):
             labels = seg_handler.read_or_create_labels(
                 label_path=label_path, num_points=points.shape[0]
             )
+            validate_segmentation_label(LabelConfig(), labels)
 
         return cls(
             path,

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -198,7 +198,7 @@ class PointCloud(object):
             msg.setInformativeText(
                 f"""
                 Do you want to overwrite 
-                the mismatch labels {labels_to_replace} with 
+                the undefined labels {labels_to_replace} with 
                 default label `{LabelConfig().get_default_class_name()}` of id `{LabelConfig().default}`?
                 """
             )

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -19,13 +19,12 @@ from PyQt5.QtWidgets import (
     QMessageBox,
 )
 
-from labelCloud.view.startup_dialog import StartupDialog
-
 from ..control.config_manager import config
 from ..definitions.types import Color3f, LabelingMode
 from ..io.labels.config import LabelConfig
 from ..labeling_strategies import PickingStrategy, SpanningStrategy
 from .settings_dialog import SettingsDialog  # type: ignore
+from .startup_dialog import StartupDialog
 from .status_manager import StatusManager
 from .viewer import GLWidget
 

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Set
 
 import pkg_resources
-from labelCloud.view.startup_dialog import StartupDialog
 from PyQt5 import QtCore, QtGui, QtWidgets, uic
 from PyQt5.QtCore import QEvent
 from PyQt5.QtGui import QPixmap
@@ -19,6 +18,8 @@ from PyQt5.QtWidgets import (
     QLabel,
     QMessageBox,
 )
+
+from labelCloud.view.startup_dialog import StartupDialog
 
 from ..control.config_manager import config
 from ..definitions.types import Color3f, LabelingMode
@@ -235,7 +236,7 @@ class GUI(QtWidgets.QMainWindow):
         # Run startup dialog
         self.startup_dialog = StartupDialog()
         if self.startup_dialog.exec():
-            self.startup_dialog.save_class_labels()
+            pass
         else:
             sys.exit()
         # Segmentation only functionalities

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -1,10 +1,10 @@
 import random
 import traceback
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import pkg_resources
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon, QPixmap, QValidator
+from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtWidgets import (
     QButtonGroup,
     QDesktopWidget,
@@ -265,18 +265,6 @@ class StartupDialog(QDialog):
             self.accept()
             return
 
-        except ZeroLabelException as e:
-            text = e.__class__.__name__
-            informative_text = str(e)
-
-        except LabelIdsNotUniqueException as e:
-            text = e.__class__.__name__
-            informative_text = str(e)
-
-        except LabelClassNameEmpty as e:
-            text = e.__class__.__name__
-            informative_text = str(e)
-
         except DefaultIdMismatchException as e:
             text = e.__class__.__name__
             informative_text = (
@@ -286,6 +274,14 @@ class StartupDialog(QDialog):
             icon = QMessageBox.Question
             buttons |= QMessageBox.Ok
             msg.accepted.connect(LabelConfig().set_first_as_default)
+
+        except (
+            ZeroLabelException,
+            LabelIdsNotUniqueException,
+            LabelClassNameEmpty,
+        ) as e:
+            text = e.__class__.__name__
+            informative_text = str(e)
 
         except Exception as e:
             text = e.__class__.__name__

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -250,7 +250,8 @@ class StartupDialog(QDialog):
 
             LabelConfig().classes = classes
             # If the default class is missing or invalid, set the first one.
-            if LabelConfig().get_default_class_name() is None:
+            if not LabelConfig().has_valid_default_class():
                 LabelConfig().default = classes[0].id
+
             LabelConfig().type = self.get_labeling_mode
             LabelConfig().save_config()

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -235,7 +235,11 @@ class StartupDialog(QDialog):
         self.class_labels.removeItem(self.class_labels.itemAt(row_index))  # type: ignore
 
     def save_class_labels(self) -> None:
-        classes = []
+        if self.nb_of_labels == 0:
+            # TODO: Change to pop-up warning.
+            raise Exception("At least one label class is required.")
+
+        classes: List[ClassConfig] = []
         for i in range(self.nb_of_labels):
 
             row: QHBoxLayout = self.class_labels.itemAt(i)  # type: ignore
@@ -243,6 +247,10 @@ class StartupDialog(QDialog):
             class_name = row.itemAt(1).widget().text()  # type: ignore
             class_color = hex_to_rgb(row.itemAt(2).widget().color())  # type: ignore
             classes.append(ClassConfig(id=class_id, name=class_name, color=class_color))
-        LabelConfig().classes = classes
-        LabelConfig().type = self.get_labeling_mode
-        LabelConfig().save_config()
+
+            LabelConfig().classes = classes
+            # If the default class is missing or invalid, set the first one.
+            if LabelConfig().get_default_class_name() is None:
+                LabelConfig().default = classes[0].id
+            LabelConfig().type = self.get_labeling_mode
+            LabelConfig().save_config()

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -1,4 +1,5 @@
 import random
+import traceback
 from typing import List, Optional, Tuple
 
 import pkg_resources
@@ -12,6 +13,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -21,22 +23,19 @@ from PyQt5.QtWidgets import (
 )
 
 from ..definitions.types import LabelingMode
-from ..io.labels.config import ClassConfig, LabelConfig
+from ..io.labels.config import (
+    ClassConfig,
+    DefaultIdMismatchException,
+    LabelClassNameEmpty,
+    LabelConfig,
+    LabelIdsNotUniqueException,
+    ZeroLabelException,
+)
 from ..utils.color import get_distinct_colors, hex_to_rgb, rgb_to_hex
 from ..view.color_button import ColorButton
 
 
-class LabelNameValidator(QValidator):
-    def validate(self, a0: str, a1: int) -> Tuple["QValidator.State", str, int]:
-        if a0 != "":
-            return (QValidator.Acceptable, a0, a1)
-        return (QValidator.Invalid, a0, a1)
-
-
 class StartupDialog(QDialog):
-
-    NAME_VALIDATOR = LabelNameValidator()
-
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.parent_gui = parent
@@ -77,7 +76,7 @@ class StartupDialog(QDialog):
 
         # 4. Row: Buttons to save or cancel
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Save)
-        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.accepted.connect(self.save)
         self.buttonBox.rejected.connect(self.reject)
 
         main_layout.addWidget(self.buttonBox)
@@ -203,7 +202,6 @@ class StartupDialog(QDialog):
         row_label.addWidget(label_id)
 
         label_name = QLineEdit(name or f"label_{id}")
-        label_name.setValidator(self.NAME_VALIDATOR)
         row_label.addWidget(label_name, stretch=2)
 
         label_color = ColorButton(color=hex_color or self.distinct_color)
@@ -234,24 +232,70 @@ class StartupDialog(QDialog):
 
         self.class_labels.removeItem(self.class_labels.itemAt(row_index))  # type: ignore
 
-    def save_class_labels(self) -> None:
-        if self.nb_of_labels == 0:
-            # TODO: Change to pop-up warning.
-            raise Exception("At least one label class is required.")
+    def get_class_config(self, row_id: int) -> ClassConfig:
+        row: QHBoxLayout = self.class_labels.itemAt(row_id)  # type: ignore
+        class_id = int(row.itemAt(0).widget().text())  # type: ignore
+        class_name = row.itemAt(1).widget().text()  # type: ignore
+        class_color = hex_to_rgb(row.itemAt(2).widget().color())  # type: ignore
+        return ClassConfig(id=class_id, name=class_name, color=class_color)
 
+    def populate_label_config(self) -> None:
         classes: List[ClassConfig] = []
         for i in range(self.nb_of_labels):
+            classes.append(self.get_class_config(i))
+        LabelConfig().classes = classes
+        LabelConfig().type = self.get_labeling_mode
 
-            row: QHBoxLayout = self.class_labels.itemAt(i)  # type: ignore
-            class_id = int(row.itemAt(0).widget().text())  # type: ignore
-            class_name = row.itemAt(1).widget().text()  # type: ignore
-            class_color = hex_to_rgb(row.itemAt(2).widget().color())  # type: ignore
-            classes.append(ClassConfig(id=class_id, name=class_name, color=class_color))
+    def _save_class_labels(self) -> None:
+        LabelConfig().validate()
+        LabelConfig().save_config()
 
-            LabelConfig().classes = classes
-            # If the default class is missing or invalid, set the first one.
-            if not LabelConfig().has_valid_default_class():
-                LabelConfig().default = classes[0].id
+    def save(self):
+        self.populate_label_config()
 
-            LabelConfig().type = self.get_labeling_mode
-            LabelConfig().save_config()
+        title = "Something went wrong"
+        text = ""
+        informative_text = ""
+        icon = QMessageBox.Critical
+        buttons = QMessageBox.Cancel
+        msg = QMessageBox()
+
+        try:
+            self._save_class_labels()
+            self.accept()
+            return
+
+        except ZeroLabelException as e:
+            text = e.__class__.__name__
+            informative_text = str(e)
+
+        except LabelIdsNotUniqueException as e:
+            text = e.__class__.__name__
+            informative_text = str(e)
+
+        except LabelClassNameEmpty as e:
+            text = e.__class__.__name__
+            informative_text = str(e)
+
+        except DefaultIdMismatchException as e:
+            text = e.__class__.__name__
+            informative_text = (
+                str(e)
+                + f" Do you want to overwrite the default to the first label `{LabelConfig().classes[0].id}`?"
+            )
+            icon = QMessageBox.Question
+            buttons |= QMessageBox.Ok
+            msg.accepted.connect(LabelConfig().set_first_as_default)
+
+        except Exception as e:
+            text = e.__class__.__name__
+            informative_text = traceback.format_exc()
+
+        msg.setWindowTitle(title)
+        msg.setText(text)
+        msg.setInformativeText(informative_text)
+        msg.setIcon(icon)
+        msg.setStandardButtons(buttons)
+        msg.setDefaultButton(QMessageBox.Cancel)
+
+        _ = msg.exec_()

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -23,11 +23,10 @@ from PyQt5.QtWidgets import (
 )
 
 from ..definitions.types import LabelingMode
-from ..io.labels.config import (
-    ClassConfig,
+from ..io.labels.config import ClassConfig, LabelConfig
+from ..io.labels.exceptions import (
     DefaultIdMismatchException,
     LabelClassNameEmpty,
-    LabelConfig,
     LabelIdsNotUniqueException,
     ZeroLabelException,
 )

--- a/labelCloud/view/startup_dialog.py
+++ b/labelCloud/view/startup_dialog.py
@@ -298,4 +298,4 @@ class StartupDialog(QDialog):
         msg.setStandardButtons(buttons)
         msg.setDefaultButton(QMessageBox.Cancel)
 
-        _ = msg.exec_()
+        msg.exec_()


### PR DESCRIPTION
**This PR addresses**:
- mismatch between segmentation labels and label definition. It prompts a message box to user to overwrite the missing labels with the default labels, if not the label stays as-is. The check happens when a PointCloud is initialised or is being saved to .bin file https://github.com/ch-sa/labelCloud/issues/124
- validate the self-correctness of the data in the StartupDialog and prompts a message box when errors occurred. Handled errors are 1. no label defined, 2. label ids are not unique, 3. label name is empty, 4. default id in the _classes.json doesn't present in the dialog. The trackback of the non-handled errors are printed to the message box.


**Screenshots of the error handling in the StartupDialog**
No label defined
![No label defined](https://user-images.githubusercontent.com/60384727/209908433-27f78f6e-911c-4ba2-adf9-785cce9489b2.png)
default id in the _classes.json doesn't present in the dialog
![image](https://user-images.githubusercontent.com/60384727/209908651-8dbdd132-a353-41ca-bc1b-af924bb2ebe0.png)
label ids are not unique
![image](https://user-images.githubusercontent.com/60384727/209908677-fa9ee6d9-3821-4ea4-abdb-c4471bc075b7.png)
label name is empty
![image](https://user-images.githubusercontent.com/60384727/209908721-84488f05-737d-4fba-8c50-556154a0c62c.png)
Unhandled error
![image](https://user-images.githubusercontent.com/60384727/209908848-d91fefa0-7c01-406c-ac88-79534f0af070.png)

**Screenshots of the message box when the segmentation labels don't match with LabelConfig**
![image](https://user-images.githubusercontent.com/60384727/209908956-63fa54af-d429-4825-be12-be93aef045d9.png)
