### PR TITLE
Crop the points inside a box and save as as a separate point cloud

### DIFF
--- a/labelCloud.py
+++ b/labelCloud.py
@@ -1,5 +1,4 @@
 from labelCloud.__main__ import main
 
 if __name__ == "__main__":
-
     main()

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -1,16 +1,12 @@
 import logging
-import traceback
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtCore import QPoint
-from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
 from ..definitions import BBOX_SIDES, Colors, Context, LabelingMode
 from ..io.labels.config import LabelConfig
-from ..io.pointclouds import BasePointCloudHandler
 from ..utils import oglhelper
 from ..view.gui import GUI
 from .alignmode import AlignMode

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -326,7 +326,9 @@ class Controller:
         assert self.pcd_manager.pointcloud is not None
         points_inside = box.is_inside(self.pcd_manager.pointcloud.points)
         pointcloud = self.pcd_manager.pointcloud.get_filtered_pointcloud(points_inside)
-
+        if pointcloud is None:
+            logging.warning("No points found inside the box. Ignored.")
+            return
         extensions = BasePointCloudHandler.get_supported_extensions()
         make_filter = " ".join(["*" + extension for extension in extensions])
         file_filter = f"Point Cloud File ({make_filter})"

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -317,10 +317,10 @@ class Controller:
             self.view.status_manager.clear_message(Context.CONTROL_PRESSED)
 
     def crop_pointcloud_inside_active_bbox(self) -> None:
-        box = self.bbox_controller.get_active_bbox()
-        assert box is not None
+        bbox = self.bbox_controller.get_active_bbox()
+        assert bbox is not None
         assert self.pcd_manager.pointcloud is not None
-        points_inside = box.is_inside(self.pcd_manager.pointcloud.points)
+        points_inside = bbox.is_inside(self.pcd_manager.pointcloud.points)
         pointcloud = self.pcd_manager.pointcloud.get_filtered_pointcloud(points_inside)
         if pointcloud is None:
             logging.warning("No points found inside the box. Ignored.")

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -329,26 +329,4 @@ class Controller:
         if pointcloud is None:
             logging.warning("No points found inside the box. Ignored.")
             return
-        extensions = BasePointCloudHandler.get_supported_extensions()
-        make_filter = " ".join(["*" + extension for extension in extensions])
-        file_filter = f"Point Cloud File ({make_filter})"
-        file_name, file_format = QFileDialog.getSaveFileName(
-            caption="Select a file name to save the cropped point cloud",
-            directory=str(pointcloud.path.parent),
-            filter=file_filter,
-            initialFilter=file_filter,
-        )
-        if file_name != "":
-            try:
-                path = Path(file_name)
-                handler = BasePointCloudHandler.get_handler(path.suffix)
-                print(path)
-                handler.write_point_cloud(path, pointcloud)
-            except Exception as e:
-                msg = QMessageBox()
-                msg.setWindowTitle("Failed to save cropped point cloud")
-                msg.setText(e.__class__.__name__)
-                msg.setInformativeText(traceback.format_exc())
-                msg.setIcon(QMessageBox.Critical)
-                msg.setStandardButtons(QMessageBox.Cancel)
-                msg.exec_()
+        self.view.save_point_cloud_as(pointcloud)

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -8,9 +8,8 @@ from shutil import copyfile
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 import numpy as np
-import pkg_resources
-
 import open3d as o3d
+import pkg_resources
 
 from ..definitions.types import LabelingMode, Point3D
 from ..io.labels.config import LabelConfig

--- a/labelCloud/io/labels/kitti.py
+++ b/labelCloud/io/labels/kitti.py
@@ -74,7 +74,6 @@ class KittiFormat(BaseLabelFormat):
 
         label_path = self.label_folder.joinpath(pcd_path.stem + self.FILE_ENDING)
         if label_path.is_file():
-
             with label_path.open("r") as read_file:
                 label_lines = read_file.readlines()
 

--- a/labelCloud/model/bbox.py
+++ b/labelCloud/model/bbox.py
@@ -20,7 +20,6 @@ from ..utils import math3d, oglhelper
 
 
 class BBox(object):
-
     MIN_DIMENSION: float = config.getfloat("LABEL", "MIN_BOUNDINGBOX_DIMENSION")
     HIGHLIGHTED_COLOR: Color3f = Color3f(0, 1, 0)
 
@@ -255,7 +254,6 @@ class BBox(object):
             self.translate_side(0, 4, distance)
 
     def is_inside(self, points: npt.NDArray[np.float32]) -> npt.NDArray[np.bool_]:
-
         vertices = self.get_vertices().copy()
 
         #        .------------.

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -355,20 +355,24 @@ class PointCloud(object):
         self.trans_x, self.trans_y, self.trans_z = self.init_rotation
         self.rot_x, self.rot_y, self.rot_z = self.init_rotation
 
-    def get_filtered_pointcloud(self, indicies: npt.NDArray[np.bool_]) -> "PointCloud":
+    def get_filtered_pointcloud(
+        self, indicies: npt.NDArray[np.bool_]
+    ) -> Optional["PointCloud"]:
         assert self.points is not None
         assert self.colors is not None
         points = self.points[indicies]
-        colors = self.colors[indicies]
-        labels = self.labels[indicies] if self.labels is not None else None
-        path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)
-        return PointCloud(
-            path=path,
-            points=points,
-            colors=colors,
-            segmentation_labels=labels,
-            write_buffer=False,
-        )
+        if points.shape[0] > 0:
+            colors = self.colors[indicies]
+            labels = self.labels[indicies] if self.labels is not None else None
+            path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)
+            return PointCloud(
+                path=path,
+                points=points,
+                colors=colors,
+                segmentation_labels=labels,
+                write_buffer=False,
+            )
+        return None
 
     def print_details(self) -> None:
         print_column(

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -361,18 +361,18 @@ class PointCloud(object):
         assert self.points is not None
         assert self.colors is not None
         points = self.points[indicies]
-        if points.shape[0] > 0:
-            colors = self.colors[indicies]
-            labels = self.labels[indicies] if self.labels is not None else None
-            path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)
-            return PointCloud(
-                path=path,
-                points=points,
-                colors=colors,
-                segmentation_labels=labels,
-                write_buffer=False,
-            )
-        return None
+        if points.shape[0] == 0:
+            return
+        colors = self.colors[indicies]
+        labels = self.labels[indicies] if self.labels is not None else None
+        path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)
+        return PointCloud(
+            path=path,
+            points=points,
+            colors=colors,
+            segmentation_labels=labels,
+            write_buffer=False,
+        )
 
     def print_details(self) -> None:
         print_column(

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -355,6 +355,21 @@ class PointCloud(object):
         self.trans_x, self.trans_y, self.trans_z = self.init_rotation
         self.rot_x, self.rot_y, self.rot_z = self.init_rotation
 
+    def get_filtered_pointcloud(self, indicies: npt.NDArray[np.bool_]) -> "PointCloud":
+        assert self.points is not None
+        assert self.colors is not None
+        points = self.points[indicies]
+        colors = self.colors[indicies]
+        labels = self.labels[indicies] if self.labels is not None else None
+        path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)
+        return PointCloud(
+            path=path,
+            points=points,
+            colors=colors,
+            segmentation_labels=labels,
+            write_buffer=False,
+        )
+
     def print_details(self) -> None:
         print_column(
             [

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -362,7 +362,7 @@ class PointCloud(object):
         assert self.colors is not None
         points = self.points[indicies]
         if points.shape[0] == 0:
-            return
+            return None
         colors = self.colors[indicies]
         labels = self.labels[indicies] if self.labels is not None else None
         path = self.path.parent / (self.path.stem + "_cropped" + self.path.suffix)

--- a/labelCloud/tests/integration/conftest.py
+++ b/labelCloud/tests/integration/conftest.py
@@ -19,7 +19,6 @@ def pytest_configure(config):
 
 @pytest.fixture
 def startup_pyqt(qtbot, qapp, monkeypatch):
-
     # Setup Model-View-Control structure
     control = Controller()
 
@@ -39,5 +38,4 @@ def startup_pyqt(qtbot, qapp, monkeypatch):
 
 @pytest.fixture
 def bbox():
-
     return BBox(cx=0, cy=0, cz=0, length=3, width=2, height=1)

--- a/labelCloud/tests/unit/segmentation_handler/test_numpy_segmentation_handler.py
+++ b/labelCloud/tests/unit/segmentation_handler/test_numpy_segmentation_handler.py
@@ -66,7 +66,6 @@ def test_create_labels(handler: NumpySegmentationHandler) -> None:
 
 
 def test_write_labels(handler: NumpySegmentationHandler) -> None:
-
     labels = np.random.randint(low=0, high=4, size=(420,), dtype=np.int8)
     with tempfile.TemporaryDirectory() as tempdir:
         label_path = Path(tempdir) / Path("foo.bin")

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -19,6 +19,8 @@ from PyQt5.QtWidgets import (
     QMessageBox,
 )
 
+from labelCloud.view.startup_dialog import StartupDialog
+
 from ..control.config_manager import config
 from ..definitions.types import Color3f, LabelingMode
 from ..io.labels.config import LabelConfig
@@ -201,7 +203,14 @@ class GUI(QtWidgets.QMainWindow):
         # self.act_rename_class = QtWidgets.QAction("Rename class") #TODO: Implement!
         self.act_change_class_color = QtWidgets.QAction("Change class color")
         self.act_delete_class = QtWidgets.QAction("Delete label")
-        self.label_list.addActions([self.act_change_class_color, self.act_delete_class])
+        self.act_crop_pointcloud_inside = QtWidgets.QAction("Save points inside as")
+        self.label_list.addActions(
+            [
+                self.act_change_class_color,
+                self.act_delete_class,
+                self.act_crop_pointcloud_inside,
+            ]
+        )
         self.label_list.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
 
         # BOUNDING BOX PARAMETER EDITS
@@ -315,6 +324,9 @@ class GUI(QtWidgets.QMainWindow):
         # context menu
         self.act_delete_class.triggered.connect(
             self.controller.bbox_controller.delete_current_bbox
+        )
+        self.act_crop_pointcloud_inside.triggered.connect(
+            self.controller.crop_pointcloud_inside_active_bbox
         )
         self.act_change_class_color.triggered.connect(self.change_label_color)
 

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -20,8 +20,6 @@ from PyQt5.QtWidgets import (
     QMessageBox,
 )
 
-from labelCloud.view.startup_dialog import StartupDialog
-
 from ..control.config_manager import config
 from ..definitions.types import Color3f, LabelingMode
 from ..io.labels.config import LabelConfig

--- a/labelCloud/view/gui.py
+++ b/labelCloud/view/gui.py
@@ -683,18 +683,19 @@ class GUI(QtWidgets.QMainWindow):
             filter=file_filter,
             initialFilter=file_filter,
         )
-        if file_name != "":
-            try:
-                path = Path(file_name)
-                handler = BasePointCloudHandler.get_handler(path.suffix)
-                handler.write_point_cloud(path, pointcloud)
-            except Exception as e:
-                msg = QMessageBox()
-                msg.setWindowTitle("Failed to save a point cloud")
-                msg.setText(e.__class__.__name__)
-                msg.setInformativeText(traceback.format_exc())
-                msg.setIcon(QMessageBox.Critical)
-                msg.setStandardButtons(QMessageBox.Cancel)
-                msg.exec_()
-        else:
+        if file_name == "":
             logging.warning("No file path provided. Ignored.")
+            return
+
+        try:
+            path = Path(file_name)
+            handler = BasePointCloudHandler.get_handler(path.suffix)
+            handler.write_point_cloud(path, pointcloud)
+        except Exception as e:
+            msg = QMessageBox()
+            msg.setWindowTitle("Failed to save a point cloud")
+            msg.setText(e.__class__.__name__)
+            msg.setInformativeText(traceback.format_exc())
+            msg.setIcon(QMessageBox.Critical)
+            msg.setStandardButtons(QMessageBox.Cancel)
+            msg.exec_()

--- a/labelCloud/view/viewer.py
+++ b/labelCloud/view/viewer.py
@@ -66,7 +66,6 @@ class GLWidget(QtOpenGL.QGLWidget):
         logging.info("Intialized widget.")
 
         # Must be written again, due to buffer clearing
-        assert self.pcd_manager is not None
         self.pcd_manager.pointcloud.create_buffers()  # type: ignore
 
     def resizeGL(self, width, height) -> None:

--- a/labelCloud/view/viewer.py
+++ b/labelCloud/view/viewer.py
@@ -1,12 +1,11 @@
 import logging
 from typing import Optional, Tuple, Union
 
-from PyQt5 import QtGui, QtOpenGL
-
 import numpy as np
 import numpy.typing as npt
 import OpenGL.GL as GL
 from OpenGL import GLU
+from PyQt5 import QtGui, QtOpenGL
 
 from ..control.alignmode import AlignMode
 from ..control.bbox_controller import BoundingBoxController
@@ -67,6 +66,7 @@ class GLWidget(QtOpenGL.QGLWidget):
         logging.info("Intialized widget.")
 
         # Must be written again, due to buffer clearing
+        assert self.pcd_manager is not None
         self.pcd_manager.pointcloud.create_buffers()  # type: ignore
 
     def resizeGL(self, width, height) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest~=7.1.2
 pytest-qt~=4.1.0
 
 # Development
-black~=22.3.0
+black~=23.1.0
 mypy~=0.971
 PyQt5-stubs~=5.15.6
 types-setuptools~=57.4.17


### PR DESCRIPTION
This PR implements a functionality to crop the point cloud inside a box and save as a separate bounding box. It reuses the menu of the boxes. A feature request here: https://github.com/ch-sa/labelCloud/issues/27

<img width="704" alt="image" src="https://user-images.githubusercontent.com/60384727/209972104-47e33330-e789-4045-a035-1febc1ba660e.png">
<img width="497" alt="image" src="https://user-images.githubusercontent.com/60384727/209972163-32a4c788-e178-4200-af30-d638acf52508.png">
<img width="782" alt="image" src="https://user-images.githubusercontent.com/60384727/209972230-c7757da2-273d-4cd1-85f6-f9d2f7699f30.png">
