### PR TITLE
Fixed import of KITTI labels via calibration files

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -5,6 +5,8 @@ pointcloud_folder = pointclouds/
 label_folder = labels/
 ; definition of classes and export format
 class_definitions = labels/_classes.json
+; only for kitti: calibration file for each point cloud
+calib_folder = calib/
 ; sink for segmentation files (*.bin point clouds) [optional]
 segmentation_folder = labels/segmentation/
 ; 2d image folder [optional]

--- a/labelCloud/io/labels/kitti.py
+++ b/labelCloud/io/labels/kitti.py
@@ -24,9 +24,11 @@ class KittiFormat(BaseLabelFormat):
         self.transformed = transformed
 
         self.calib_folder = config.getpath("FILE", "calib_folder")
+        self.bboxes_meta: List[Dict] = []
 
     def import_labels(self, pcd_path: Path) -> List[BBox]:
-        labels = []
+        bboxes = []
+        self.bboxes_meta = []
 
         label_path = self.label_folder.joinpath(pcd_path.stem + self.FILE_ENDING)
         calib_path = self.calib_folder.joinpath(pcd_path.stem + self.FILE_ENDING)
@@ -37,10 +39,20 @@ class KittiFormat(BaseLabelFormat):
 
             for line in label_lines:
                 line_elements = line.split()
-                centroid = tuple([float(v) for v in line_elements[11:14]])
-                dimensions = tuple([float(v) for v in line_elements[8:11]])
+                meta = {
+                    "type": line_elements[0],
+                    "truncated": line_elements[1],
+                    "occluded": line_elements[2],
+                    "alpha": line_elements[3],
+                    "bbox": " ".join(line_elements[4:8]),
+                    "dimensions": " ".join(line_elements[8:11]),
+                    "location": " ".join(line_elements[11:14]),
+                    "rotation_y": line_elements[14],
+                }
+                self.bboxes_meta.append(meta)
+                centroid = tuple([float(v) for v in meta["location"].split()])
+                dimensions = tuple([float(v) for v in meta["dimensions"].split()])
                 if self.transformed:
-
                     if not calib_path.is_file():
                         logging.exception(
                             f"There is no calibration file for point cloud {pcd_path.name}."
@@ -50,9 +62,9 @@ class KittiFormat(BaseLabelFormat):
                         )
                         return []
 
-                    T_c2l = self.calc_cam2lidar(calib_path)
+                    self._calc_transforms(calib_path)
                     xyz1 = np.insert(np.asarray(centroid), 3, values=[1])
-                    xyz1 = T_c2l @ xyz1
+                    xyz1 = self.T_c2v @ xyz1
                     centroid = tuple([float(n) for n in xyz1[:-1]])
                     dimensions = dimensions[2], dimensions[1], dimensions[0]
                     centroid = (
@@ -61,51 +73,45 @@ class KittiFormat(BaseLabelFormat):
                         centroid[2] + dimensions[2] / 2,
                     )  # centroid in KITTI located on bottom face of bbox
                 bbox = BBox(*centroid, *dimensions)
-                if self.transformed:
-                    bbox.set_rotations(
-                        0, 0, rel2abs_rotation(-float(line_elements[14]) + math.pi / 2)
-                    )
-                else:
-                    bbox.set_rotations(0, 0, rel2abs_rotation(float(line_elements[14])))
-                bbox.set_classname(line_elements[0])
-                labels.append(bbox)
+                rotation = -float(meta["rotation_y"]) + math.pi / 2 if self.transformed else float(meta["rotation_y"])
+                bbox.set_rotations(0, 0, rel2abs_rotation(rotation))
+                bbox.set_classname(meta["type"])
+                bboxes.append(bbox)
             logging.info("Imported %s labels from %s." % (len(label_lines), label_path))
-        return labels
+        return bboxes
 
     def export_labels(self, bboxes: List[BBox], pcd_path: Path) -> None:
         data = str()
 
         # Labels
-        for bbox in bboxes:
+        for i, bbox in enumerate(bboxes):
             obj_type = bbox.get_classname()
             centroid = bbox.get_center()
-            if self.transformed:
-                centroid = (-centroid[1], centroid[2] + 2.3, centroid[0])
-            location = " ".join([str(self.round_dec(v)) for v in centroid])
             dimensions = bbox.get_dimensions()
             if self.transformed:
-                dimensions = (dimensions[2], dimensions[1], dimensions[0])
+                centroid = (
+                    centroid[0],
+                    centroid[1],
+                    centroid[2] - dimensions[2] / 2,
+                )  # centroid in KITTI located on bottom face of bbox
+                dimensions = dimensions[2], dimensions[1], dimensions[0]
+                xyz1 = np.insert(np.asarray(centroid), 3, values=[1])
+                xyz1 = self.T_v2c @ xyz1
+                centroid = tuple([float(n) for n in xyz1[:-1]])
+            location_str = " ".join([str(self.round_dec(v)) for v in centroid])
             dimensions_str = " ".join([str(self.round_dec(v)) for v in dimensions])
-            rotation_z = bbox.get_z_rotation()
-            if self.transformed:
-                rotation_y = self.round_dec(
-                    -(abs2rel_rotation(rotation_z) - math.pi / 2)
-                )
-            else:
-                rotation_y = self.round_dec(abs2rel_rotation(rotation_z))
+            rotation = bbox.get_z_rotation()
+            rotation = abs2rel_rotation(rotation)
+            rotation = -(rotation - math.pi / 2) if self.transformed else rotation
+            rotation = str(self.round_dec(rotation))
 
-            data += (
-                " ".join(
-                    [
-                        obj_type,
-                        "0 0 0 0 0 0 0",
-                        dimensions_str,
-                        location,
-                        str(rotation_y),
-                    ]
-                )
-                + "\n"
-            )
+            out_str = list(self.bboxes_meta[i].values())
+            if obj_type != "DontCare":
+                out_str[5] = dimensions_str
+                out_str[6] = location_str
+                out_str[7] = rotation
+
+            data += (" ".join(out_str) + "\n")
 
         # Save to TXT
         path_to_file = self.save_label_to_file(pcd_path, data)
@@ -130,7 +136,7 @@ class KittiFormat(BaseLabelFormat):
             calib_dict[vals[0][:-1]] = np.array(vals[1:]).astype(np.float64)
         return calib_dict
 
-    def calc_cam2lidar(self, calib_path: Path):
+    def _calc_transforms(self, calib_path: Path) -> None:
         calib_dict = self._read_calib(calib_path)
 
         T_rect = calib_dict["R0_rect"]
@@ -142,5 +148,5 @@ class KittiFormat(BaseLabelFormat):
         T_v2c = T_v2c.reshape(3, 4)
         T_v2c = np.insert(T_v2c, 3, values=[0, 0, 0, 1], axis=0)
 
-        T_c2v = np.linalg.inv(T_rect @ T_v2c)
-        return T_c2v
+        self.T_v2c = T_rect @ T_v2c
+        self.T_c2v = np.linalg.inv(self.T_v2c)

--- a/labelCloud/io/labels/kitti.py
+++ b/labelCloud/io/labels/kitti.py
@@ -73,7 +73,11 @@ class KittiFormat(BaseLabelFormat):
                         centroid[2] + dimensions[2] / 2,
                     )  # centroid in KITTI located on bottom face of bbox
                 bbox = BBox(*centroid, *dimensions)
-                rotation = -float(meta["rotation_y"]) + math.pi / 2 if self.transformed else float(meta["rotation_y"])
+                rotation = (
+                    -float(meta["rotation_y"]) + math.pi / 2
+                    if self.transformed
+                    else float(meta["rotation_y"])
+                )
                 bbox.set_rotations(0, 0, rel2abs_rotation(rotation))
                 bbox.set_classname(meta["type"])
                 bboxes.append(bbox)
@@ -97,13 +101,13 @@ class KittiFormat(BaseLabelFormat):
                 dimensions = dimensions[2], dimensions[1], dimensions[0]
                 xyz1 = np.insert(np.asarray(centroid), 3, values=[1])
                 xyz1 = self.T_v2c @ xyz1
-                centroid = tuple([float(n) for n in xyz1[:-1]])
+                centroid = tuple([float(n) for n in xyz1[:-1]])  # type: ignore
             location_str = " ".join([str(self.round_dec(v)) for v in centroid])
             dimensions_str = " ".join([str(self.round_dec(v)) for v in dimensions])
             rotation = bbox.get_z_rotation()
             rotation = abs2rel_rotation(rotation)
             rotation = -(rotation - math.pi / 2) if self.transformed else rotation
-            rotation = str(self.round_dec(rotation))
+            rotation = str(self.round_dec(rotation))  # type: ignore
 
             out_str = list(self.bboxes_meta[i].values())
             if obj_type != "DontCare":
@@ -111,7 +115,7 @@ class KittiFormat(BaseLabelFormat):
                 out_str[6] = location_str
                 out_str[7] = rotation
 
-            data += (" ".join(out_str) + "\n")
+            data += " ".join(out_str) + "\n"
 
         # Save to TXT
         path_to_file = self.save_label_to_file(pcd_path, data)

--- a/labelCloud/io/labels/kitti.py
+++ b/labelCloud/io/labels/kitti.py
@@ -73,7 +73,6 @@ class KittiFormat(BaseLabelFormat):
         bboxes = []
 
         label_path = self.label_folder.joinpath(pcd_path.stem + self.FILE_ENDING)
-        calib_path = self.calib_folder.joinpath(pcd_path.stem + self.FILE_ENDING)
         if label_path.is_file():
 
             with label_path.open("r") as read_file:
@@ -129,7 +128,7 @@ class KittiFormat(BaseLabelFormat):
         data = str()
 
         # Labels
-        for i, bbox in enumerate(bboxes):
+        for bbox in bboxes:
             obj_type = bbox.get_classname()
             centroid = bbox.get_center()
             dimensions = bbox.get_dimensions()
@@ -172,6 +171,8 @@ class KittiFormat(BaseLabelFormat):
             f"Exported {len(bboxes)} labels to {path_to_file} "
             f"in {self.__class__.__name__} formatting!"
         )
+        self.T_v2c = None
+        self.T_c2v = None
 
     # ---------------------------------------------------------------------------- #
     #                               Helper Functions                               #

--- a/labelCloud/resources/default_config.ini
+++ b/labelCloud/resources/default_config.ini
@@ -5,6 +5,8 @@ pointcloud_folder = pointclouds/
 label_folder = labels/
 ; definition of classes and export format
 class_definitions = labels/_classes.json
+; only for kitti: calibration file for each point cloud
+calib_folder = calib/
 ; sink for segmentation files (*.bin point clouds) [optional]
 segmentation_folder = labels/segmentation/
 ; 2d image folder [optional]


### PR DESCRIPTION
I assumed that `calib` folder is located next to `labels`. 