### PR TITLE
Fix issue with GUI not accepting floats.

### DIFF
--- a/labelCloud/__main__.py
+++ b/labelCloud/__main__.py
@@ -96,8 +96,8 @@ def start_gui():
 
     app.setStyle("Fusion")
     desktop = QDesktopWidget().availableGeometry()
-    width = (desktop.width() - view.width()) / 2
-    height = (desktop.height() - view.height()) / 2
+    width = (desktop.width() - view.width()) // 2
+    height = (desktop.height() - view.height()) // 2
     view.move(width, height)
 
     logging.info("Showing GUI...")


### PR DESCRIPTION
I was having trouble running labelCloud on Windows. Passing floats to a Qt function where it expected integers crashed the program. I'll include the error message if I can find the time to reproduce, but here's the patch for now.