### PR TITLE
New hotkeys and bbox autoselection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,18 +109,24 @@ All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the pos
 |                               Shortcut                               | Description                                          |
 | :------------------------------------------------------------------: | ---------------------------------------------------- |
 |                             *Navigation*                             |                                                      |
-|                          Left Mouse Button                           | Rotates the Point Cloud                              |
-|                          Right Mouse Button                          | Translates the Point Cloud                           |
+|                          Left Mouse Button                           | Rotates the camera around Point Cloud centroid       |
+|                          Right Mouse Button                          | Translates the camera                                |
 |                             Mouse Wheel                              | Zooms into the Point Cloud                           |
 |                             *Correction*                             |                                                      |
-|         `W`, `A`, `S`, `D` <br> `Ctrl` + Right Mouse Button          | Translates the Bounding Box back, left, front, right |
+|                          `W`, `A`, `S`, `D`                          | Translates the Bounding Box back, left, front, right |
+|                     `Ctrl` + Right Mouse Button                      | Translates the Bounding Box in all dimensions        |
 |                               `Q`, `E`                               | Lifts the Bounding Box up, down                      |
-|                               `X`, `Y`                               | Rotates the Boundign Box around z-Axis               |
+|                               `Z`, `X`                               | Rotates the Boundign Box around z-Axis               |
+|                               `C`, `V`                               | Rotates the Boundign Box around y-Axis               |
+|                               `B`, `N`                               | Rotates the Boundign Box around x-Axis               |
 | Scrolling with the Cursor above a Bounding Box Side ("Side Pulling") | Changes the Dimension of the Bounding Box            |
-|                         `C` & `V`, `B` & `N`                         | Rotates the Bounding Box around y-Axis, x-Axis       |
+|                         `R`/`Left`, `F`/`Right`                      | Previous/Next sample                                 |
+|                           `T`/`Up`, `G`/`Down`                       | Previous/Next bbox                                   |
+|                             `Y`/`,`,`H`/`.`                          | Change current bbox class to previous/next in list   |
+|                                `1`-`9`                               | Select any of first 9 bboxes with number keys        |
 |                              *General*                               |                                                      |
 |                                `Del`                                 | Deletes Current Bounding Box                         |
-|                                 `R`                                  | Resets Perspective                                   |
+|                              `P`/`Home`                              | Resets Perspective                                   |
 |                                `Esc`                                 | Cancels Selected Points                              |
 
 

--- a/labelCloud/io/labels/config.py
+++ b/labelCloud/io/labels/config.py
@@ -110,6 +110,19 @@ class LabelConfig(object, metaclass=SingletonABCMeta):
     def get_class(self, class_name: str) -> ClassConfig:
         return self.get_classes()[class_name]
 
+    def get_relative_class(self, current_class: str, step: int) -> str:
+        """Get class, relative to current by id according to given step"""
+        if step == 0:
+            return current_class
+        id2name = {cc.id: cc.name for cc in self.classes}
+        name2id = {v: k for k, v in id2name.items()}
+        ids = name2id.values()
+        corner_case_id = max(ids) if step < 0 else min(ids)
+        current_id = name2id[current_class]
+        result_id = current_id + step
+        result_id = result_id if result_id in ids else corner_case_id
+        return id2name[result_id]
+
     def get_class_color(self, class_name: str) -> Color3f:
         try:
             return self.get_classes()[class_name].color


### PR DESCRIPTION
In this PR I implemented some workflow improvements stated in #143:
- First bbox autoselection on sample change
- New hotkeys for sample/bbox/class switch
- Updated list of hotkeys in README.md
 
A bit of reasoning under new hotkeys:
During labeling I noticed, that I use the program in two modes:
1. Labeling sequential dataset
2. Fixing incorrect labeling

In (1) I have left hand on keyboard and right on mouse, so I need all keys be accesible with one hand (all keys should be near `WASD`).
In (2) case I don't need mouse and can use keyboard only (arrows to navigate dataset with right hand and free left hand to fix errors).