### PR TITLE
fix the changing problem of l,w,h

### DIFF
--- a/labelCloud/io/labels/centroid.py
+++ b/labelCloud/io/labels/centroid.py
@@ -19,7 +19,13 @@ class CentroidFormat(BaseLabelFormat):
                 data = json.load(read_file)
 
             for label in data["objects"]:
-                bbox = BBox(*label["centroid"].values(), *label["dimensions"].values())
+                x = label["centroid"]["x"]
+                y = label["centroid"]["y"]
+                z = label["centroid"]["z"]
+                length = label["dimensions"]["length"]
+                width = label["dimensions"]["width"]
+                height = label["dimensions"]["height"]
+                bbox = BBox(x, y, z, length, width, height)
                 rotations = label["rotations"].values()
                 if self.relative_rotation:
                     rotations = map(rel2abs_rotation, rotations)


### PR DESCRIPTION
minor fix:

When you change the order of the '`l`,' '`w`,' and '`h`' attributes in a JSON file, the box size is affected by the `*label["dimensions"]` operation.