### PR TITLE
Add keyboard shortcuts for scaling, allow loading files recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,15 @@ All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the pos
 |                          `W`, `A`, `S`, `D`                          | Translates the Bounding Box back, left, front, right |
 |                     `Ctrl` + Right Mouse Button                      | Translates the Bounding Box in all dimensions        |
 |                               `Q`, `E`                               | Lifts the Bounding Box up, down                      |
-|                               `Z`, `X`                               | Rotates the Boundign Box around z-Axis               |
-|                               `C`, `V`                               | Rotates the Boundign Box around y-Axis               |
-|                               `B`, `N`                               | Rotates the Boundign Box around x-Axis               |
+|                               `Z`, `X`                               | Rotates the Bounding Box around z-Axis               |
+|                               `C`, `V`                               | Rotates the Bounding Box around y-Axis               |
+|                               `B`, `N`                               | Rotates the Bounding Box around x-Axis               |
+|                          `I`, `K`, `,`                               | Increase the Bounding Box length/width/height        |
+|                          `O`, `L`, `.`                               | Decrease the Bounding Box length/width/height        |
 | Scrolling with the Cursor above a Bounding Box Side ("Side Pulling") | Changes the Dimension of the Bounding Box            |
 |                         `R`/`Left`, `F`/`Right`                      | Previous/Next sample                                 |
 |                           `T`/`Up`, `G`/`Down`                       | Previous/Next bbox                                   |
-|                             `Y`/`,`,`H`/`.`                          | Change current bbox class to previous/next in list   |
+|                             `Y`, `H`                                 | Change current bbox class to previous/next in list   |
 |                                `1`-`9`                               | Select any of first 9 bboxes with number keys        |
 |                              *General*                               |                                                      |
 |                                `Del`                                 | Deletes Current Bounding Box                         |
@@ -150,11 +152,11 @@ If you are using the tool for a scientific project please consider citing our [p
         author = {Christoph Sager and Patrick Zschech and Niklas Kuhl},
         title = {{labelCloud}: A Lightweight Labeling Tool for Domain-Agnostic 3D Object Detection in Point Clouds},
         journal = {Computer-Aided Design and Applications}
-    } 
-   
+    }
+
     # CAD Conference
     @misc{sager2021labelcloud,
-      title={labelCloud: A Lightweight Domain-Independent Labeling Tool for 3D Object Detection in Point Clouds}, 
+      title={labelCloud: A Lightweight Domain-Independent Labeling Tool for 3D Object Detection in Point Clouds},
       author={Christoph Sager and Patrick Zschech and Niklas Kühl},
       year={2021},
       eprint={2103.04970},

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ All rotations are counterclockwise (i.e. a z-rotation of 90°/π is from the pos
 |                               `Z`, `X`                               | Rotates the Bounding Box around z-Axis               |
 |                               `C`, `V`                               | Rotates the Bounding Box around y-Axis               |
 |                               `B`, `N`                               | Rotates the Bounding Box around x-Axis               |
-|                          `I`, `K`, `,`                               | Increase the Bounding Box length/width/height        |
-|                          `O`, `L`, `.`                               | Decrease the Bounding Box length/width/height        |
+|                               `I`/ `O`                               | Increase/Decrease the Bounding Box length            |
+|                               `K`/ `L`                               | Increase/Decrease the Bounding Box width             |
+|                               `,`/ `.`                               | Increase/Decrease the Bounding Box height            |
 | Scrolling with the Cursor above a Bounding Box Side ("Side Pulling") | Changes the Dimension of the Bounding Box            |
 |                         `R`/`Left`, `F`/`Right`                      | Previous/Next sample                                 |
 |                           `T`/`Up`, `G`/`Down`                       | Previous/Next bbox                                   |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -5,16 +5,25 @@ There are a number of shortcuts supported for frequently used actions.
 |                               Shortcut                               | Description                                          |
 | :------------------------------------------------------------------: | ---------------------------------------------------- |
 |                             *Navigation*                             |                                                      |
-|                          Left Mouse Button                           | Rotates the Point Cloud                              |
-|                          Right Mouse Button                          | Translates the Point Cloud                           |
+|                          Left Mouse Button                           | Rotates the camera around Point Cloud centroid       |
+|                          Right Mouse Button                          | Translates the camera                                |
 |                             Mouse Wheel                              | Zooms into the Point Cloud                           |
 |                             *Correction*                             |                                                      |
-|         `W`, `A`, `S`, `D` <br> `Ctrl` + Right Mouse Button          | Translates the Bounding Box back, left, front, right |
+|                          `W`, `A`, `S`, `D`                          | Translates the Bounding Box back, left, front, right |
+|                     `Ctrl` + Right Mouse Button                      | Translates the Bounding Box in all dimensions        |
 |                               `Q`, `E`                               | Lifts the Bounding Box up, down                      |
-|                               `X`, `Y`                               | Rotates the Bounding Box around z-Axis               |
+|                               `Z`, `X`                               | Rotates the Bounding Box around z-Axis               |
+|                               `C`, `V`                               | Rotates the Bounding Box around y-Axis               |
+|                               `B`, `N`                               | Rotates the Bounding Box around x-Axis               |
+|                               `I`/ `O`                               | Increase/Decrease the Bounding Box length            |
+|                               `K`/ `L`                               | Increase/Decrease the Bounding Box width             |
+|                               `,`/ `.`                               | Increase/Decrease the Bounding Box height            |
 | Scrolling with the Cursor above a Bounding Box Side ("Side Pulling") | Changes the Dimension of the Bounding Box            |
-|                         `C` & `V`, `B` & `N`                         | Rotates the Bounding Box around y-Axis, x-Axis       |
+|                         `R`/`Left`, `F`/`Right`                      | Previous/Next sample                                 |
+|                           `T`/`Up`, `G`/`Down`                       | Previous/Next bbox                                   |
+|                             `Y`, `H`                                 | Change current bbox class to previous/next in list   |
+|                                `1`-`9`                               | Select any of first 9 bboxes with number keys        |
 |                              *General*                               |                                                      |
 |                                `Del`                                 | Deletes Current Bounding Box                         |
-|                                 `R`                                  | Resets Perspective                                   |
+|                              `P`/`Home`                              | Resets Perspective                                   |
 |                                `Esc`                                 | Cancels Selected Points                              |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -11,7 +11,7 @@ There are a number of shortcuts supported for frequently used actions.
 |                             *Correction*                             |                                                      |
 |         `W`, `A`, `S`, `D` <br> `Ctrl` + Right Mouse Button          | Translates the Bounding Box back, left, front, right |
 |                               `Q`, `E`                               | Lifts the Bounding Box up, down                      |
-|                               `X`, `Y`                               | Rotates the Boundign Box around z-Axis               |
+|                               `X`, `Y`                               | Rotates the Bounding Box around z-Axis               |
 | Scrolling with the Cursor above a Bounding Box Side ("Side Pulling") | Changes the Dimension of the Bounding Box            |
 |                         `C` & `V`, `B` & `N`                         | Rotates the Bounding Box around y-Axis, x-Axis       |
 |                              *General*                               |                                                      |

--- a/labelCloud/control/alignmode.py
+++ b/labelCloud/control/alignmode.py
@@ -3,6 +3,7 @@ A module for aligning point clouds with the floor. The user has to span a triang
 three points on the plane that serves as the ground. Then the old point cloud will be
 saved up and the aligned current will overwrite the old.
 """
+
 import logging
 from typing import TYPE_CHECKING, Optional
 

--- a/labelCloud/control/bbox_controller.py
+++ b/labelCloud/control/bbox_controller.py
@@ -298,41 +298,41 @@ class BoundingBoxController(object):
 
     @has_active_bbox_decorator
     def scale_along_length(
-        self, size_increase: Optional[float] = None, decrease: bool = False
+        self, step: Optional[float] = None, decrease: bool = False
     ) -> None:
-        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        step = step or config.getfloat("LABEL", "std_scaling")
         if decrease:
-            size_increase *= -1
+            step *= -1
 
         active_bbox: Bbox = self.get_active_bbox()  # type: ignore
         length, width, height = active_bbox.get_dimensions()
-        new_length = length + size_increase
+        new_length = length + step
         active_bbox.set_dimensions(new_length, width, height)
 
     @has_active_bbox_decorator
     def scale_along_width(
-        self, size_increase: Optional[float] = None, decrease: bool = False
+        self, step: Optional[float] = None, decrease: bool = False
     ) -> None:
-        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        step = step or config.getfloat("LABEL", "std_scaling")
         if decrease:
-            size_increase *= -1
+            step *= -1
 
         active_bbox: Bbox = self.get_active_bbox()  # type: ignore
         length, width, height = active_bbox.get_dimensions()
-        new_width = width + size_increase
+        new_width = width + step
         active_bbox.set_dimensions(length, new_width, height)
 
     @has_active_bbox_decorator
     def scale_along_height(
-        self, size_increase: Optional[float] = None, decrease: bool = False
+        self, step: Optional[float] = None, decrease: bool = False
     ) -> None:
-        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        step = step or config.getfloat("LABEL", "std_scaling")
         if decrease:
-            size_increase *= -1
+            step *= -1
 
         active_bbox: Bbox = self.get_active_bbox()  # type: ignore
         length, width, height = active_bbox.get_dimensions()
-        new_height = height + size_increase
+        new_height = height + step
         active_bbox.set_dimensions(length, width, new_height)
 
     def select_bbox_by_ray(self, x: int, y: int) -> None:

--- a/labelCloud/control/bbox_controller.py
+++ b/labelCloud/control/bbox_controller.py
@@ -4,6 +4,7 @@ settings in one place.
 Bounding Box Management: adding, selecting updating, deleting bboxes;
 Possible Active Bounding Box Manipulations: rotation, translation, scaling
 """
+
 import logging
 from functools import wraps
 from typing import TYPE_CHECKING, List, Optional

--- a/labelCloud/control/bbox_controller.py
+++ b/labelCloud/control/bbox_controller.py
@@ -296,6 +296,45 @@ class BoundingBoxController(object):
 
         self.get_active_bbox().set_dimensions(new_length, new_width, new_height)  # type: ignore
 
+    @has_active_bbox_decorator
+    def scale_along_length(
+        self, size_increase: Optional[float] = None, decrease: bool = False
+    ) -> None:
+        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        if decrease:
+            size_increase *= -1
+
+        active_bbox: Bbox = self.get_active_bbox()  # type: ignore
+        length, width, height = active_bbox.get_dimensions()
+        new_length = length + size_increase
+        active_bbox.set_dimensions(new_length, width, height)
+
+    @has_active_bbox_decorator
+    def scale_along_width(
+        self, size_increase: Optional[float] = None, decrease: bool = False
+    ) -> None:
+        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        if decrease:
+            size_increase *= -1
+
+        active_bbox: Bbox = self.get_active_bbox()  # type: ignore
+        length, width, height = active_bbox.get_dimensions()
+        new_width = width + size_increase
+        active_bbox.set_dimensions(length, new_width, height)
+
+    @has_active_bbox_decorator
+    def scale_along_height(
+        self, size_increase: Optional[float] = None, decrease: bool = False
+    ) -> None:
+        size_increase = size_increase or config.getfloat("LABEL", "std_scaling")
+        if decrease:
+            size_increase *= -1
+
+        active_bbox: Bbox = self.get_active_bbox()  # type: ignore
+        length, width, height = active_bbox.get_dimensions()
+        new_height = height + size_increase
+        active_bbox.set_dimensions(length, width, new_height)
+
     def select_bbox_by_ray(self, x: int, y: int) -> None:
         intersected_bbox_id = oglhelper.get_intersected_bboxes(
             x,

--- a/labelCloud/control/config_manager.py
+++ b/labelCloud/control/config_manager.py
@@ -1,4 +1,5 @@
 """Load configuration from .ini file."""
+
 import configparser
 from pathlib import Path
 from typing import List, Union

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -344,10 +344,10 @@ class Controller:
         elif a0.key() in [Keys.Key_G, Keys.Key_Down]:
             # select previous bbox
             self.select_relative_bbox(1)
-        elif a0.key() in [Keys.Key_Y, Keys.Key_Comma]:
+        elif a0.key() in Keys.Key_Y:
             # change bbox class to previous available class
             self.select_relative_class(-1)
-        elif a0.key() in [Keys.Key_H, Keys.Key_Period]:
+        elif a0.key() in Keys.Key_H:
             # change bbox class to next available class
             self.select_relative_class(1)
         elif a0.key() in list(range(49, 58)):

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -311,6 +311,27 @@ class Controller:
         elif a0.key() == Keys.Key_E:
             # move down
             self.bbox_controller.translate_along_z(down=True)
+
+        # BBOX Scaling
+        elif a0.key() == Keys.Key_I:
+            # increase length
+            self.bbox_controller.scale_along_length()
+        elif a0.key() == Keys.Key_O:
+            # decrease length
+            self.bbox_controller.scale_along_length(decrease=True)
+        elif a0.key() == Keys.Key_K:
+            # increase width
+            self.bbox_controller.scale_along_width()
+        elif a0.key() == Keys.Key_L:
+            # decrease width
+            self.bbox_controller.scale_along_width(decrease=True)
+        elif a0.key() == Keys.Key_Comma:
+            # increase height
+            self.bbox_controller.scale_along_height()
+        elif a0.key() == Keys.Key_Period:
+            # decrease height
+            self.bbox_controller.scale_along_height(decrease=True)
+
         elif a0.key() in [Keys.Key_R, Keys.Key_Left]:
             # load previous sample
             self.prev_pcd()

--- a/labelCloud/control/controller.py
+++ b/labelCloud/control/controller.py
@@ -344,10 +344,10 @@ class Controller:
         elif a0.key() in [Keys.Key_G, Keys.Key_Down]:
             # select previous bbox
             self.select_relative_bbox(1)
-        elif a0.key() in Keys.Key_Y:
+        elif a0.key() == Keys.Key_Y:
             # change bbox class to previous available class
             self.select_relative_class(-1)
-        elif a0.key() in Keys.Key_H:
+        elif a0.key() == Keys.Key_H:
             # change bbox class to next available class
             self.select_relative_class(1)
         elif a0.key() in list(range(49, 58)):

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -60,7 +60,7 @@ class PointCloudManger(object):
         """Checks point cloud folder and sets self.pcds to all valid point cloud file names."""
         if self.pcd_folder.is_dir():
             self.pcds = []
-            for file in sorted(self.pcd_folder.iterdir()):
+            for file in sorted(self.pcd_folder.rglob("*")):
                 if file.suffix in PointCloudManger.PCD_EXTENSIONS:
                     self.pcds.append(file)
         else:

--- a/labelCloud/control/pcd_manager.py
+++ b/labelCloud/control/pcd_manager.py
@@ -2,6 +2,7 @@
 Module to manage the point clouds (loading, navigation, floor alignment).
 Sets the point cloud and original point cloud path. Initiate the writing to the virtual object buffer.
 """
+
 import logging
 from pathlib import Path
 from shutil import copyfile
@@ -41,9 +42,8 @@ class PointCloudManger(object):
 
         # Point cloud control
         self.pointcloud: Optional[PointCloud] = None
-        self.collected_object_classes: Set[
-            str
-        ] = set()  # TODO: this should integrate with the new label definition setup.
+        # TODO: this should integrate with the new label definition setup.
+        self.collected_object_classes: Set[str] = set()
         self.saved_perspective: Optional[Perspective] = None
 
     @property

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -394,9 +394,9 @@ class PointCloud(object):
                     else (
                         green(len(self.colors))  # type: ignore
                         if len(self.colors) == len(self.points)  # type: ignore
-                        else red(len(self.colors))
+                        else red(len(self.colors))  # type: ignore
                     )
-                ),  # type: ignore
+                ),
             ]
         )
         print_column(["Point Cloud Center:", str(np.round(self.center, 2))])

--- a/labelCloud/model/point_cloud.py
+++ b/labelCloud/model/point_cloud.py
@@ -378,19 +378,25 @@ class PointCloud(object):
         print_column(
             [
                 "Number of Points:",
-                green(len(self.points))
-                if len(self.points) > 0
-                else red(len(self.points)),
+                (
+                    green(len(self.points))
+                    if len(self.points) > 0
+                    else red(len(self.points))
+                ),
             ]
         )
         print_column(
             [
                 "Number of Colors:",
-                yellow("None")
-                if self.colorless
-                else green(len(self.colors))  # type: ignore
-                if len(self.colors) == len(self.points)  # type: ignore
-                else red(len(self.colors)),  # type: ignore
+                (
+                    yellow("None")
+                    if self.colorless
+                    else (
+                        green(len(self.colors))  # type: ignore
+                        if len(self.colors) == len(self.points)  # type: ignore
+                        else red(len(self.colors))
+                    )
+                ),  # type: ignore
             ]
         )
         print_column(["Point Cloud Center:", str(np.round(self.center, 2))])

--- a/labelCloud/utils/oglhelper.py
+++ b/labelCloud/utils/oglhelper.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
     from ..model import BBox, PointCloud
 
 
-DEVICE_PIXEL_RATIO: Optional[
-    float
-] = None  # is set once and for every window resize (retina display fix)
+DEVICE_PIXEL_RATIO: Optional[float] = (
+    None  # is set once and for every window resize (retina display fix)
+)
 
 
 def draw_points(
@@ -178,9 +178,9 @@ def get_intersected_sides(
     p0, p1 = get_pick_ray(x, y, modelview, projection)  # Calculate picking ray
     vertices = bbox.get_vertices()
 
-    intersections: List[
-        Tuple[list, str]
-    ] = list()  # (intersection_point, bounding box side)
+    intersections: List[Tuple[list, str]] = (
+        list()
+    )  # (intersection_point, bounding box side)
     for side, indices in BBOX_SIDES.items():
         # Calculate plane equation
         pl1 = vertices[indices[0]]  # point in plane

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest~=7.3.1
 pytest-qt~=4.2.0
 
 # Development
-black~=23.1.0
+black>=23.1.0
 mypy~=1.3.0
 PyQt5-stubs~=5.15.6
 types-setuptools~=67.8.0


### PR DESCRIPTION
This PR adds keyboard shortcuts for increasing/decreasing bbox scale (length, width, height).
I extended the documentation to reflect this change.

It also includes a small change to load pointcloud files recursively.